### PR TITLE
DTLS support in the experimental UDP forwarding type

### DIFF
--- a/uavcan/internet/udp/32750.OutgoingPacket.0.1.uavcan
+++ b/uavcan/internet/udp/32750.OutgoingPacket.0.1.uavcan
@@ -125,8 +125,9 @@ uint8[<=45] destination_address
 @assert _offset_ % 8 == {0}
 
 # Option flags.
-bool use_masquerading   # Expect data back (i.e., instruct the modem to use the NAT table)
-void6
+bool use_masquerading   # Expect data back (i.e., instruct the modem to use the NAT table).
+bool use_dtls           # Use Datagram Transport Layer Security. Drop the packet if DTLS is not supported.
+void5
 
 # Effective payload. This data will be forwarded to the remote host verbatim.
 # UDP packets that contain more than 508 bytes of payload may be dropped by some types of


### PR DESCRIPTION
Users shouldn't have to roll their own crypto. UAVCAN makes an implicit assumption that the intra-vehicular network is secure; being situated on the edge between the secure vehicular network and the outside world, modems can be burdened with security enforcement activities. Any UDP traffic can be tunneled via DTLS (it's one of the DTLS's design goals) virtually without changes to the application layer, so this type can be used as the optimal point of abstraction above the two.