### PR TITLE
Fix to #66 and minor clarifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "3.6"
 before_install:
-  - pip install pydsdl>=0.7
+  - pip install pydsdl~=1.0
 script:
   - ./test.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2018 UAVCAN Development Team
+Copyright (c) 2014-2019 UAVCAN Development Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Regulated DSDL definitions
 ==========================
 
-[![Build Status](https://travis-ci.org/UAVCAN/dsdl.svg?branch=master)](https://travis-ci.org/UAVCAN/dsdl)
+[![Build Status](https://travis-ci.org/UAVCAN/public_regulated_data_types.svg?branch=master)](https://travis-ci.org/UAVCAN/public_regulated_data_types)
 [![Forum](https://img.shields.io/discourse/https/forum.uavcan.org/users.svg)](https://forum.uavcan.org)
 
 This repository contains definitions of the regulated UAVCAN data types.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Regulated DSDL definitions
 [![Forum](https://img.shields.io/discourse/https/forum.uavcan.org/users.svg)](https://forum.uavcan.org)
 
 This repository contains definitions of the regulated UAVCAN data types.
+[UAVCAN](http://uavcan.org) is an open lightweight protocol designed for reliable communication
+in aerospace and robotic applications via robust vehicle bus networks such as CAN, Ethernet, and similar.
+The name stands for *Uncomplicated Application-level Vehicular Communication And Networking*.
+
 Regulated data types include the standard data types and vendor-specific public definitions.
 
 Per the specification, standard data types are contained in the root namespace `uavcan`,
@@ -18,11 +22,7 @@ defined by the specification before submitting the pull request.
 
 Contributors must obey the guidelines defined in this document.
 
-UAVCAN is an open lightweight protocol designed for reliable communication in aerospace and robotic applications via
-robust vehicle bus networks.
-
-* [**UAVCAN website**](http://uavcan.org)
-* [**UAVCAN forum**](https://forum.uavcan.org)
+Feedback and proposals are welcome on the [UAVCAN forum](https://forum.uavcan.org).
 
 ## Identifier ranges
 

--- a/uavcan/diagnostic/32760.Record.1.0.uavcan
+++ b/uavcan/diagnostic/32760.Record.1.0.uavcan
@@ -1,6 +1,6 @@
 #
 # Generic human-readable text message for logging and displaying purposes.
-# Generally it should be published at the lowest priority level.
+# Generally, it should be published at the lowest priority level.
 #
 
 # Optional timestamp in the network-synchronized time system; zero if undefined.

--- a/uavcan/node/32085.Heartbeat.1.0.uavcan
+++ b/uavcan/node/32085.Heartbeat.1.0.uavcan
@@ -1,8 +1,9 @@
 #
 # Abstract node status information.
-#
-# All UAVCAN nodes are required to publish this message periodically.
 # This is the only high-level function that must be implemented by all nodes.
+#
+# All UAVCAN nodes that have a node-ID are required to publish this message periodically.
+# Nodes that do not have a node-ID (also known as "anonymous nodes") shall not publish this message.
 #
 # The default subject ID 32085 is 111110101010101 in binary. The alternating bit pattern at the end
 # helps transceiver synchronization (e.g., on CAN-based networks) and on some transports permits

--- a/uavcan/node/434.GetTransportStatistics.0.1.uavcan
+++ b/uavcan/node/434.GetTransportStatistics.0.1.uavcan
@@ -1,22 +1,24 @@
 #
 # Returns a set of general low-level transport statistical counters.
-# Servers are not required to sample the data atomically.
+# Servers are encouraged but not required to sample the data atomically.
 #
 
 ---
 
 # UAVCAN supports up to triply modular redundant interfaces.
-uint8 MAX_PHYSICAL_INTERFACES = 3
+uint8 MAX_NETWORK_INTERFACES = 3
 
 # UAVCAN transfer performance statistics:
-# the number of UAVCAN transfers sent, received, and failed.
+# the number of UAVCAN transfers successfully sent, successfully received, and failed.
+# The methods of error counting are implementation-defined.
 IOStatistics.0.1 transfer_statistics
 
-# Physical interface statistics, separate per interface.
+# Network interface statistics, separate per interface.
 # E.g., for a doubly redundant transport, this array would contain two elements,
 # the one at the index zero would apply to the first interface, the other to the second interface.
+# The methods of counting are implementation-defined.
 void6
-IOStatistics.0.1[<=MAX_PHYSICAL_INTERFACES] physical_interface_statistics
+IOStatistics.0.1[<=MAX_NETWORK_INTERFACES] network_interface_statistics
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max <= (63 * 8)      # One CAN FD frame

--- a/uavcan/node/ID.1.0.uavcan
+++ b/uavcan/node/ID.1.0.uavcan
@@ -1,5 +1,5 @@
 #
-# Defines a node ID.
+# Defines a node-ID.
 # The maximum valid value is dependent on the underlying transport layer.
 # Values lower than 128 are always valid for all transports.
 # Refer to the specification for more info.

--- a/uavcan/node/IOStatistics.0.1.uavcan
+++ b/uavcan/node/IOStatistics.0.1.uavcan
@@ -1,8 +1,18 @@
 #
-# A standard set of generic input/output statistical counters that should never overflow (in a realistic scenario).
+# A standard set of generic input/output statistical counters that generally should not overflow.
 # If a 40-bit counter is incremented every millisecond, it will overflow in ~35 years.
+# If an overflow occurs, the value will wrap over to zero.
+#
+# The values should not be reset while the node is running.
 #
 
+# The number of successfully emitted entities.
 truncated uint40 num_emitted
+
+# The number of successfully received entities.
 truncated uint40 num_received
+
+# How many errors have occurred.
+# The exact definition of "error" and how they are counted are implementation-defined,
+# unless specifically defined otherwise.
 truncated uint40 num_errored

--- a/uavcan/node/port/431.List.0.1.uavcan
+++ b/uavcan/node/port/431.List.0.1.uavcan
@@ -1,21 +1,20 @@
 #
-# Returns a subset of all ports of the specified kind (service or message) on the remote node.
+# Returns a subset of all ports of the specified kind (subject or service) on the remote node.
 # As the number of ports may exceed the capacity of the output array, the server will return only those which are
-# greater than the number specified in the request. The caller should sweep the lower boundary upwards until
-# the size of the returned array is less than its capacity. For example:
+# not less than the number specified in the request. The caller should sweep the lower boundary upwards until
+# the size of the returned array is strictly less than its capacity. For example:
 # 1. port_id_lower_boundary =    0; port_ids = [42, 567, ... 920]    (=128 elements, continue)
 # 2. port_id_lower_boundary =  920; port_ids = [1052,    ... 5049]   (=128 elements, continue)
 # 3. port_id_lower_boundary = 5049; port_ids = [6973,    ..., 24593] (<128 elements, stop)
 #
-
-# The server will return as many IDs as possible which are numerically greater than this lower boundary,
-# and which are of the same kind as specified in the request (i.e., if the lower boundary is a service ID, only
-# service IDs will be returned).
+# The server will return as many IDs as possible which are numerically not less than port_id_lower_boundary,
+# and which are of the same kind as specified in the request (i.e., if the lower boundary is a service-ID, only
+# service-IDs will be returned).
 #
-# If the number of matching (i.e., greater than this limit) IDs exceeds the capacity of the output array,
-# the caller will need to repeat the call with this boundary set to the maximum value found in the returned array.
-# The calls should be repeated while advancing the boundary as described until the returned array is not full
-# (e.g. the number of elements is less than its capacity, possibly zero).
+# If the number of matching (i.e., not less than port_id_lower_boundary) IDs exceeds the capacity of the output array,
+# the caller will need to repeat the call with this boundary set to the value one greater than the maximum found
+# in the returned array. The calls should be repeated while advancing the boundary as described until
+# the returned array is not full (e.g. the number of elements is less than its capacity, possibly zero).
 #
 # The server is NOT required to ensure any ordering in the output array, meaning that the caller will have to
 # search through the array in order to find the greatest value in it.
@@ -23,13 +22,20 @@
 # The server is REQUIRED to ensure that every element in the returned array is unique.
 #
 # The server is REQUIRED to ensure that by performing the above actions the client will end up with a full set of
-# port IDs, assuming that the set is not modified between invocations. This implicitly requires that there must be
-# no port ID that is lower than the greatest value in the returned array that is not listed in the array, because
+# port-IDs, assuming that the set is not modified between invocations. This implicitly requires that there must be
+# no port-ID that is lower than the greatest value in the returned array that is not listed in the array, because
 # in that case the client will never be able to obtain that value.
-void7
+#
+# For subjects, both subscription (input) and publication (output) ports shall be returned.
+# If necessary, the caller will be able to differentiate between those by using the sibling service type GetInfo.
+#
+# For services, server ports shall be returned. Whether client ports are returned is implementation-defined.
+# As in the case of subjects, further differentiation is possible via GetInfo.
+#
+
 ID.1.0 port_id_lower_boundary
 
-@assert _offset_ == {24}
+@assert _offset_ == {16}
 
 ---
 

--- a/uavcan/node/port/432.GetInfo.0.1.uavcan
+++ b/uavcan/node/port/432.GetInfo.0.1.uavcan
@@ -1,30 +1,48 @@
 #
-# This service is used to obtain information about a port (either message or service).
-# It can be used for advanced network inspections, e.g. for building computational graph maps.
+# This service is used to obtain information about a port (either subject or service).
+# It can be used for advanced network inspections, e.g., for building computational graph maps.
+#
+# If this service is implemented, it shall report information for all subject ports (both publishers and subscribers)
+# and service server ports Support for service client ports is optional (implementation-defined);
+# if not supported, client ports may be reported as non-existent.
+#
+# The reason client ports are treated differently is due to their inherent volatility: services are often
+# invoked ad-hoc, and the network stack on the client node may choose to reclaim the resources allocated for
+# a client port that is no longer in use for other needs.
 #
 
-# The port of interest; can be either a service or a message.
-void7
+# The port of interest; can be either a service or a subject.
 ID.1.0 port_id
 
-@assert _offset_ == {24}
+@assert _offset_ == {16}
 
 ---
 
-# Flags describing the current port.
-# Note that a message port can be both subscriber and publisher at the same time.
-bool is_subscriber      # Message input port
-bool is_publisher       # Message output port
-bool is_server          # Server port
-void5
+# For subject ports, "input" means subscriber and "output" means publisher.
+# A subject port may be both subscriber and publisher at the same time.
+#
+# For service ports, "input" means server and "output" means client (based on the direction of request transfers).
+# A service port may be both server and client at the same time.
+#
+# For non-existent ports both flags should be cleared.
+#
+#   Kind        | Input         | Output
+# --------------+---------------+----------------
+#   Subject     | Subscriber    | Publisher
+#   Service     | Server        | Client
+#
+bool is_input       # Subscriber or server
+bool is_output      # Publisher or client
+void6
 
-# If such port exists, this field must contain the full name of its data type.
-# If the requested port does not exist, this field must be empty.
-# If this field is empty, the caller must ignore all other fields.
+# If such port exists, this field shall contain the full name of its data type.
+# If the requested port does not exist, this field shall be empty.
+# If this field is empty, the caller should ignore all other fields.
 void2
 uint8[<=50] data_type_full_name
 
 # The version numbers of the data type used at this port.
+# Zeros if the port does not exist.
 uavcan.node.Version.1.0 data_type_version
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/node/port/433.GetStatistics.0.1.uavcan
+++ b/uavcan/node/port/433.GetStatistics.0.1.uavcan
@@ -17,12 +17,16 @@ ID.1.0 port_id
 # should be equal; however, under certain circumstances the number of responses ("emitted") can be
 # lower, e.g. if the server could not or chose not to send a response.
 #
+# The "emitted" and "received" counters reflect the number of successful transactions only.
+# Failed transcations should not affect their values; instead, they should be reflected in the error counter.
+#
 # The error counter represents how many transfers could not be successfully received or emitted due to
-# an error of any kind anywhere in the processing pipeline, excluding application-level errors.
+# an error of any kind anywhere in the network stack, excluding application-level errors.
 # For example, if the message could not be decoded because of a data type compatibility problem,
 # such incident should be reported here via this field. On the other hand, if the message or service
 # call was processed properly, but the application could not act upon that data, it should not be
 # reported here because that problem should be attributed to a different level of abstraction.
+# The exact definition of an error and the methods of their counting are implementation-defined.
 uavcan.node.IOStatistics.0.1 statistics
 
 @assert _offset_ == {15 * 8}      # 15 bytes max; this service is optimized for high-frequency polling

--- a/uavcan/node/port/433.GetStatistics.0.1.uavcan
+++ b/uavcan/node/port/433.GetStatistics.0.1.uavcan
@@ -4,10 +4,9 @@
 #
 
 # The port of interest; can be either a service or a message.
-void7
 ID.1.0 port_id
 
-@assert _offset_ == {24}
+@assert _offset_ == {16}
 
 ---
 

--- a/uavcan/node/port/ID.1.0.uavcan
+++ b/uavcan/node/port/ID.1.0.uavcan
@@ -4,6 +4,6 @@
 #
 
 @union
-ServiceID.1.0 service_id
 SubjectID.1.0 subject_id
-@assert _offset_ == {17}
+ServiceID.1.0 service_id
+@assert _offset_ == {16}

--- a/uavcan/node/port/ServiceID.1.0.uavcan
+++ b/uavcan/node/port/ServiceID.1.0.uavcan
@@ -4,7 +4,7 @@
 
 uint9 MAX_UNREGULATED_ID = 127
 
-void7
+void6
 uint9 value
 
-@assert _offset_ == {16}
+@assert _offset_ == {15}

--- a/uavcan/node/port/ServiceID.1.0.uavcan
+++ b/uavcan/node/port/ServiceID.1.0.uavcan
@@ -1,5 +1,5 @@
 #
-# Service ID. The ranges are defined by the specification.
+# Service-ID. The ranges are defined by the specification.
 #
 
 uint9 MAX_UNREGULATED_ID = 127

--- a/uavcan/node/port/SubjectID.1.0.uavcan
+++ b/uavcan/node/port/SubjectID.1.0.uavcan
@@ -1,5 +1,5 @@
 #
-# Subject ID. The ranges are defined by the specification.
+# Subject-ID. The ranges are defined by the specification.
 #
 
 uint16 MAX_UNREGULATED_ID = 24575

--- a/uavcan/node/port/SubjectID.1.0.uavcan
+++ b/uavcan/node/port/SubjectID.1.0.uavcan
@@ -4,7 +4,6 @@
 
 uint16 MAX_UNREGULATED_ID = 24575
 
-void1
 uint15 value
 
-@assert _offset_ == {16}
+@assert _offset_ == {15}

--- a/uavcan/pnp/32742.NodeIDAllocationDataMTU8.0.1.uavcan
+++ b/uavcan/pnp/32742.NodeIDAllocationDataMTU8.0.1.uavcan
@@ -10,9 +10,9 @@
 # the full 128-bit ID with a smaller 55-bit hash of it, and remove support for preferred node-ID value in the
 # allocation requests in order to save space.
 #
-# The 55-bit hash is obtained by applying an atbitrary hash function to the unique-ID that outputs at least 55 bit of
+# The 55-bit hash is obtained by applying an arbitrary hash function to the unique-ID that outputs at least 55 bit of
 # data. For example, it could be the standard CRC-64WE function where only the lowest 55 bit of the result are used.
-# The hash function must always produce the same hash value for the same unique-ID value, and it must be likely to
+# The hash function shall produce the same hash value for the same unique-ID value, and it should be likely to
 # produce a different hash value for any other unique-ID value.
 #
 # Allocators that support both the general case and the small-MTU case should maintain the same allocation table
@@ -22,6 +22,9 @@
 # obtain a "pseudo unique-ID", and use this value in the allocation table as a substitute for the real unique-ID.
 # It is recognized that this behavior will have certain side effects, such as the same allocatee obtaining different
 # allocated node-ID values depending on which transport is used, but they are considered tolerable.
+#
+# Allocatees that may need to operate over low-MTU transports along with high-MTU transports may choose to use
+# only this constrained method of allocation for consistency and simplification of the behaviors.
 #
 # In order to save space for the hash, the preferred node-ID is removed from the request. The allocated node-ID
 # is provided in the response, however; this is achieved by means of an optional field that is not populated in

--- a/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
+++ b/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
@@ -74,8 +74,8 @@ uint8 DEFAULT_MAX_ELECTION_TIMEOUT = 4      # [second]
 # Refer to the Raft paper for explanation.
 uint32 term
 uint32 prev_log_term
-uint8 prev_log_index
-uint8 leader_commit
+uint16 prev_log_index
+uint16 leader_commit
 
 # Worst case replication time per Follower can be computed as:
 #

--- a/uavcan/pnp/cluster/391.RequestVote.1.0.uavcan
+++ b/uavcan/pnp/cluster/391.RequestVote.1.0.uavcan
@@ -5,7 +5,7 @@
 # Refer to the Raft paper for explanation.
 uint32 term
 uint32 last_log_term
-uint8 last_log_index
+uint16 last_log_index
 
 ---
 

--- a/uavcan/register/384.Access.1.0.uavcan
+++ b/uavcan/register/384.Access.1.0.uavcan
@@ -128,6 +128,7 @@ void2
 # Empty value means that the register does not exist (in this case the flags should be cleared/ignored).
 # By comparing the returned value against the write request the caller can determine whether the register
 # was written successfully, unless write was not requested.
+# An empty value shall never be returned for an existing register.
 Value.1.0 value
 
 @assert _offset_.min % 8 == 0

--- a/uavcan/register/384.Access.1.0.uavcan
+++ b/uavcan/register/384.Access.1.0.uavcan
@@ -56,6 +56,14 @@
 #   - minimum value is contained in the register named "system.parameter>" (optional)
 #   - default value is contained in the register named "system.parameter=" (optional)
 #
+# The type and dimensionality of the special function registers containing the minimum, maximum, and the default
+# value of a register shall be the same as those of the register.
+#
+# If a written value exceeds the minimum/maximum specified by the respective special function registers,
+# the server may either adjust the value automatically, or to retain the old value, depending on which behavior
+# suits the objectives of the application better.
+# The values of registers containing non-scalar numerical entities should be compared elementwise.
+#
 # The following table specifies the register name patterns that are reserved by the specification for
 # common functions. Implementers should always follow these conventions whenever applicable.
 # The table uses the following abbreviations for register flags:

--- a/uavcan/register/385.List.1.0.uavcan
+++ b/uavcan/register/385.List.1.0.uavcan
@@ -2,6 +2,9 @@
 # This service allows the caller to discover the names of all registers available on the server
 # by iterating the index field from zero until an empty name is returned.
 #
+# The ordering of the registers shall remain constant while the server is running.
+# The ordering is not guaranteed to remain unchanged when the server node is restarted.
+#
 
 uint16 index
 


### PR DESCRIPTION
A review is optional.

After this PR is merged, I propose to swap the branches so that the current master becomes the dedicated v0 branch and the current `uavcan-v1` becomes the new master. This is already done for PyUAVCAN: https://github.com/UAVCAN/pyuavcan/branches

Many data types are not yet stable, but thanks to the new versioning system we don't need to stabilize them in order to stabilize the whole namespace. Thanks, Kjetil.