### PR TITLE
Updated all definitions under uavcan.si.sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,17 @@ Namespace                   | Lower bound (inclusive)
 The namespace `uavcan.si` contains a collection of generic data types describing commonly used
 physical quantities.
 
+The namespace `uavcan.si.unit` contains basic units that can be used as type-safe wrappers over native `float32`
+and other scalar and array types.
+
+The namespace `uavcan.si.sample` contains time-stamped versions of the above, where the timestamp field is
+always located at the end in order to make the time-stamped types structural sub-types of the non-timestamped ones.
+The structural sub-typing enhances interoperability.
+At some point in the future, when the DSDL has advanced sufficiently, it may be possible to express the subtyping
+relationships explicitly.
+
 All units follow the [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units).
-All units are unscaled basic units of measure (e.g., meters rather than kilometers, kilograms rather than milligrams),
-unless a different multiplier is explicitly specified in the definition (e.g., nanosecond).
+All units are unscaled basic units of measure -- meters rather than kilometers, kilograms rather than milligrams.
 
 All coordinate systems are right-handed.
 In relation to body, the preferred standard is as follows: **X** -- forward, **Y** -- right, **Z** -- down.

--- a/uavcan/si/sample/acceleration/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/acceleration/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 meter_per_second_per_second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/acceleration/Vector3.1.0.uavcan
+++ b/uavcan/si/sample/acceleration/Vector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[3] meter_per_second_per_second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/angle/Quaternion.1.0.uavcan
+++ b/uavcan/si/sample/angle/Quaternion.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[4] wxyz
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/angle/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/angle/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 radian
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/angular_velocity/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/angular_velocity/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 radian_per_second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/angular_velocity/Vector3.1.0.uavcan
+++ b/uavcan/si/sample/angular_velocity/Vector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[3] radian_per_second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/duration/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/duration/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/duration/WideScalar.1.0.uavcan
+++ b/uavcan/si/sample/duration/WideScalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float64 second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/electric_charge/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/electric_charge/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 coulomb
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/electric_current/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/electric_current/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 ampere
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/energy/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/energy/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 joule
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/force/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/force/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 newton
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/force/Vector3.1.0.uavcan
+++ b/uavcan/si/sample/force/Vector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[3] newton
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/frequency/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/frequency/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 hertz
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/length/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/length/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 meter
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/length/Vector3.1.0.uavcan
+++ b/uavcan/si/sample/length/Vector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[3] meter
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/length/WideVector3.1.0.uavcan
+++ b/uavcan/si/sample/length/WideVector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float64[3] meter
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/magnetic_field_strength/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/magnetic_field_strength/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 tesla
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/magnetic_field_strength/Vector3.1.0.uavcan
+++ b/uavcan/si/sample/magnetic_field_strength/Vector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[3] tesla
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/mass/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/mass/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 kilogram
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/power/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/power/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 watt
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/pressure/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/pressure/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 pascal
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/temperature/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/temperature/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 kelvin
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/torque/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/torque/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 newton_meter
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/torque/Vector3.1.0.uavcan
+++ b/uavcan/si/sample/torque/Vector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[3] newton_meter
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/velocity/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/velocity/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 meter_per_second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/velocity/Vector3.1.0.uavcan
+++ b/uavcan/si/sample/velocity/Vector3.1.0.uavcan
@@ -1,3 +1,3 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32[3] meter_per_second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 @assert _offset_ % 8 == {0}

--- a/uavcan/si/sample/voltage/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/voltage/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 volt
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/volume/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/volume/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 cubic_meter
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/si/sample/volumetric_flow_rate/Scalar.1.0.uavcan
+++ b/uavcan/si/sample/volumetric_flow_rate/Scalar.1.0.uavcan
@@ -1,2 +1,2 @@
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 float32 cubic_meter_per_second
+uavcan.time.SynchronizedTimestamp.1.0 timestamp

--- a/uavcan/time/SynchronizedTimestamp.1.0.uavcan
+++ b/uavcan/time/SynchronizedTimestamp.1.0.uavcan
@@ -2,6 +2,10 @@
 # Nested data type used for representing a network-wide synchronized timestamp with microsecond resolution.
 # This data type is highly recommended for use both in standard and vendor-specific messages alike.
 #
+# If a data type is available in timestamped and non-timestamped form, its timestamped version should put
+# the timestamp at the end, in order to make the timestamped version a structural subtype of the non-timestamped
+# one, thus enhancing interoperability.
+#
 
 # Zero means that the time is not known.
 uint56 UNKNOWN = 0


### PR DESCRIPTION
Updated all definitions under `uavcan.si.sample` to make them structural subtypes of their counterparts under uavcan.si.unit.

This change is related to https://github.com/UAVCAN/specification/pull/64.

The breakage is acceptable because v1 is not yet used in production and is not yet released.