### PR TITLE
Comments go after statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Non-standard (vendor-specific) types are recommended to follow this advice as we
 Follow the naming conventions defined in the specification.
 
 Every data type definition shall have a header comment, where the first and the last lines are empty;
-every field shall be preceded by a comment, unless it is absolutely certain that it is completely
+every field shall be followed by a comment, unless it is absolutely certain that it is completely
 self-explanatory.
 An exception is made for trivial definitions which often do not require any additional comments.
 
@@ -179,24 +179,20 @@ The lines of text should not be longer than 120 characters.
 
 Here is an example:
 
-    #
     # This is a header comment.
     # It explains what this data type definition is for and why do we need it.
-    # Mind the blank comment lines before and after the header comment.
-    #
 
-    # This space is reserved for future use.
-    void42
+    void42  # This space is reserved for future use.
 
+    uint8 VALUE_A = 1       # A comment describing the constant.
+    uint8 VALUE_B = 2       # Another one. Constants go before the field they relate to.
+    uint8 value
     # This is an enumeration.
     # We don't need blank lines because the items are tightly related.
-    uint8 VALUE_A = 1       # A comment describing the constant.
-    uint8 VALUE_B = 2       # Another one.
-    uint8 value
 
-    # This is a new field, mind the blank line above.
     void1
     float32[<100] aligned_array
+    # This is a new field, mind the blank line above.
 
 Remember, the set of standard data types is an important part of the protocol specification,
 so the quality of the documentation is very important.

--- a/regulated/zubax/actuator/esc/AngVelSetpoint.0.1.uavcan
+++ b/regulated/zubax/actuator/esc/AngVelSetpoint.0.1.uavcan
@@ -1,9 +1,7 @@
-#
 # Setpoints for the mechanical speed control loop of an ESC.
 # Each setpoint value contains the target mechanical angular velocity of the motor in rad/s.
 # Negative values indicate reverse rotation.
 # If reversal is not supported, negative values should be treated as zero setpoint.
-#
 
 void2
 uavcan.si.unit.angular_velocity.Scalar.1.0[<64] motor_mechanical_angular_velocity

--- a/regulated/zubax/actuator/esc/RatiometricSetpoint.0.1.uavcan
+++ b/regulated/zubax/actuator/esc/RatiometricSetpoint.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # A unitless ratiometric setpoint value belongs to [-512, 511].
 # -512 maps to full reverse, and 511 maps to full forward motion.
 # The width of the deadband is strictly zero (no deadband).
@@ -14,7 +13,6 @@
 # a vector control ESC may map the setpoint to the Q-axis voltage vector projection or torque.
 #
 # The scalar type is chosen to make five setpoints fit into one classic CAN frame (max 7 bytes of payload per frame).
-#
 
 int10[<64] ratiometric
 

--- a/regulated/zubax/actuator/esc/Status.0.1.uavcan
+++ b/regulated/zubax/actuator/esc/Status.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # Electronic speed controller (ESC) group status.
 #
 # This interface assumes that ESCs are segregated into groups.
@@ -30,52 +29,50 @@
 # The published status values should be low-pass filtered with an adequate cutoff frequency to avoid aliasing effects.
 # Implementations should strive to sample all parameters atomically whenever possible.
 # If a parameter is unknown, NaN should be used.
-#
 
-# Publication frequency limits.
 uint8 MAX_PUBLICATION_PERIOD = 1  # [second]
+# Publication frequency limits.
 
 void2
-
+uint6 index
 # The index in the setpoint array that this status message refers to.
 # This value should never be changed while the node is running.
-uint6 index
 
-# Percentage of the maximum rated power output. May exceed 100% in case of overload.
 uint8 demand_factor  # [percent]
+# Percentage of the maximum rated power output. May exceed 100% in case of overload.
 
-# A warning flag is set when the corresponding parameter exceeds the safe operating area (SOA) of the ESC.
+void12
 bool dc_voltage_warning             # DC link voltage above or below the SOA.
 bool overload_warning               # Output power/current above SOA or regeneration below the SOA.
 bool motor_temperature_warning      # Temperature above or below the SOA.
 bool inverter_temperature_warning   # Temperature above or below the SOA.
-void12
+# A warning flag is set when the corresponding parameter exceeds the safe operating area (SOA) of the ESC.
 
 @assert _offset_ % 32 == {0}
 
-# Incremented once per occurrence. The exact definition of what constitutes an error is implementation-dependent.
 uint32 error_count
+# Incremented once per occurrence. The exact definition of what constitutes an error is implementation-dependent.
 
+uavcan.si.unit.angular_velocity.Scalar.1.0 motor_mechanical_angular_velocity  # Negative indicates reverse rotation.
+uavcan.si.unit.torque.Scalar.1.0           motor_torque                       # Opposite sign indicates regeneration.
 # Real-time motion parameters.
 # If the mechanical load consumes the power (motoring), the torque and the angular velocity have the same sign.
 # If the mechanical load delivers the power (regeneration), the torque and the angular velocity have opposite signs.
 # Therefore, negative mechanical power (ang_vel*torque) indicates regeneration.
-uavcan.si.unit.angular_velocity.Scalar.1.0 motor_mechanical_angular_velocity  # Negative indicates reverse rotation.
-uavcan.si.unit.torque.Scalar.1.0           motor_torque                       # Opposite sign indicates regeneration.
 
+uavcan.si.unit.frequency.Scalar.1.0 motor_electrical_frequency
 # Electric field frequency is always non-negative, irrespective of the direction.
 # For synchronous motors, this is a function of the mechanical angular velocity and the number of rotor poles.
-uavcan.si.unit.frequency.Scalar.1.0 motor_electrical_frequency
 
-# DC link parameters. Negative current indicates regeneration.
 regulated.zubax.sensor.wattmeter.DCSample.0.1 dc_link_power
+# DC link parameters. Negative current indicates regeneration.
 
-# Sampled temperatures. If multiple values are available, reduction is implementation-defined.
-# We use raw float16 here instead of the more type-safe SI types to reduce the footprint.
 float16 motor_temperature     # [kelvin]
 float16 inverter_temperature  # [kelvin]
+# Sampled temperatures. If multiple values are available, reduction is implementation-defined.
+# We use raw float16 here instead of the more type-safe SI types to reduce the footprint.
 
-void32  # Reserved for future use.
+void32
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.count == 1     # Fixed-size

--- a/regulated/zubax/sensor/bms/BatteryPackParams.0.1.uavcan
+++ b/regulated/zubax/sensor/bms/BatteryPackParams.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # Smart battery parameter message. This is a top-level data type.
 # This message is modeled after the Smart Battery Data Specification (SBS) and the MAVLink battery status messages.
 # Please read the documentation for the pack status message type first.
@@ -10,65 +9,62 @@
 # each pack on a separate subject.
 #
 # Parameters are specified for the pack rather than per-cell, unless explicitly stated otherwise.
-#
 
+uavcan.si.unit.mass.Scalar.1.0 mass
 # The total mass of the pack, including the packaging, electronics, cabling, and all auxiliary items, if any.
 # NaN if unknown.
-uavcan.si.unit.mass.Scalar.1.0 mass
 
+uavcan.si.unit.electric_charge.Scalar.1.0 design_capacity
 # The maximum total charge of the pack, at 100% SoH, specified by the manufacturer.
 # NaN if unknown.
-uavcan.si.unit.electric_charge.Scalar.1.0 design_capacity
 
+uavcan.si.unit.electric_current.Scalar.1.0 design_load_current
 # The maximum load current of the pack specified by the manufacturer.
 # NaN if unknown.
-uavcan.si.unit.electric_current.Scalar.1.0 design_load_current
 
+uavcan.si.unit.voltage.Scalar.1.0[3] design_cell_voltage_min_typ_max
 # The minimum (end of discharge), nominal (resting), and the maximum (end of charge) cell voltages
 # specified by the manufacturer. The number of cells is reported in the status message.
 # Constraints: minimum <= nominal <= maximum.
 # Use best guess or NaN if any of the values are unknown.
 # Example: [2.8, 3.6, 4.2] V.
-uavcan.si.unit.voltage.Scalar.1.0[3] design_cell_voltage_min_typ_max
 
+uavcan.si.unit.voltage.Scalar.1.0          design_charging_voltage
+uavcan.si.unit.electric_current.Scalar.1.0 design_charging_current
 # The charging parameters specified by the manufacturer for the pack.
 # This is a reflection of similar parameters from the Smart Battery Data Specification.
 # NaN if unknown.
-uavcan.si.unit.voltage.Scalar.1.0          design_charging_voltage
-uavcan.si.unit.electric_current.Scalar.1.0 design_charging_current
 
+uint32 CYCLE_COUNT_UNKNOWN = 2 ** 32 - 1
+uint32 cycle_count
 # The number of charge-discharge cycles. Zero if the battery is new. May increase at runtime.
 # What constitutes a charge-discharge cycle is implementation-defined.
-uint32 cycle_count
-uint32 CYCLE_COUNT_UNKNOWN = 2 ** 32 - 1
 
-# Shall not change at runtime.
 Technology.0.1 technology
+# Shall not change at runtime.
 
 void1
-
+uint7 state_of_health
 # The SoH of the pack, ranges from 0 to 100. May change at runtime.
 # If not provided by the BMS, use best guess or report 100%.
-uint7 state_of_health
 
 void64
 void64
 
-# Vendor-specific identification or diagnostic information. May change at runtime depending on its use.
 uint64 vendor_specific_parameter
+# Vendor-specific identification or diagnostic information. May change at runtime depending on its use.
 
+uint64 unique_id
 # The unique identifier of the battery whose parameters are reported.
 # Vendors should obtain a random ID for every manufactured battery.
 # If the battery is interfaced via SBS, the unique ID can be computed as a hash
 # of the manufacturer name, device name, serial number, and the manufacture date.
-uint64 unique_id
 
 @assert (_offset_ % 8 == {0}) && (_offset_.count == 1)
 
 void2
-
+uint8[<64] name
 # The name of the vendor and model encoded in UTF8.
 # Example: "MyBattCo MBC101 v1.1"
-uint8[<64] name
 
 @assert _offset_ % 8 == {0}

--- a/regulated/zubax/sensor/bms/BatteryPackStatus.0.1.uavcan
+++ b/regulated/zubax/sensor/bms/BatteryPackStatus.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # Smart battery status message. This is a top-level data type.
 # This message is modeled after the Smart Battery Data Specification (SBS) and the MAVLink battery status messages.
 #
@@ -27,26 +26,25 @@
 # The methods of energy estimation are implementation-defined.
 #
 # pragma: no-bit-length-limit
-#
 
-# The network-synchronized timestamp of the moment where the values contained in this message have been sampled.
 uavcan.time.SynchronizedTimestamp.1.0 timestamp
+# The network-synchronized timestamp of the moment where the values contained in this message have been sampled.
 
 # --------------------------  ESTIMATES  --------------------------
 
 void1
-
+uint7 state_of_charge  # [percent]
 # The instant SoC of the pack, ranges from 0 to 100. Mandatory.
 # The methods of estimation are implementation-defined.
-uint7 state_of_charge  # [percent]
 
 @assert _offset_ % 32 == {0}
 
+regulated.zubax.sensor.wattmeter.DCSample.0.1 power
 # Total instant pack power. Low-pass filtering should be applied to avoid aliasing effects.
 # Positive current flows from the battery to the load (discharging).
 # Negative current flows into the battery (charging).
-regulated.zubax.sensor.wattmeter.DCSample.0.1 power
 
+uavcan.si.unit.energy.Scalar.1.0 energy
 # A pessimistic estimate of the amount of energy that can be reclaimed from the battery in its current state.
 # This may be dependent on the state of charge (SoC), state of health (SoH), temperature, load profile, etc.
 # Negative values may be reported to indicate overdischarge.
@@ -56,63 +54,61 @@ regulated.zubax.sensor.wattmeter.DCSample.0.1 power
 # factors that may affect the amount of reclaimable energy, so it may be preferable. Having the instant power,
 # the time to depletion is estimated as (energy / power). When charging, the remaining time to full charge
 # can be found similarly as ((full_energy - energy) / abs(power)).
-uavcan.si.unit.energy.Scalar.1.0 energy
 
+uavcan.si.unit.energy.Scalar.1.0 full_energy
 # A pessimistic estimate of the amount of energy that can be reclaimed from a fully charged battery
 # under the current conditions (SoH, temperature, load profile, etc).
-uavcan.si.unit.energy.Scalar.1.0 full_energy
 
+float16[2] temperature_min_max  # [kelvin]
 # The minimum and maximum readings of the pack temperature sensors. For example, if a pack is equipped with
 # three distributed temperature sensors that read [288, 258.15, 360.5] kelvin, the reported array value would be
 # [258.15, 360.5].
 # If there is only one temperature sensor, both elements shall be of the same value.
 # If there are no temperature sensors, both elements shall be NaN.
-float16[2] temperature_min_max  # [kelvin]
 
 @assert _offset_ % 8 == {0}
 
 # --------------------------  STATUS FLAGS  --------------------------
 
+bool charger_connected
 # Whether the charging is in progress is observable though the reported instant current: a negative value
 # indicates that the battery is being charged. Time to full charge can be derived from the energy estimate.
-bool charger_connected
 
-# The temperature of at least one cell/section of the battery is above or below the safe operating limits.
-# Note that the flags are not mutually exclusive.
 bool temperature_hot
 bool temperature_cold
+# The temperature of at least one cell/section of the battery is above or below the safe operating limits.
+# Note that the flags are not mutually exclusive.
 
-# The charge or discharge rate exceeds the safe operating limits.
 bool overload
+# The charge or discharge rate exceeds the safe operating limits.
 
-# The cells require rebalancing. This may be an indicator of deterioration of the battery.
 bool disbalance
+# The cells require rebalancing. This may be an indicator of deterioration of the battery.
 
-# Cell balancing is currently in progress.
 bool balancing
+# Cell balancing is currently in progress.
 
+bool needs_service
 # The battery requires other type of maintenance (not balancing).
 # Use vendor-specific interfaces to obtain further information.
-bool needs_service
 
+bool bms_error
 # Internal error in the battery management system, not related to the battery itself.
 # Use vendor-specific interfaces to obtain further information.
-bool bms_error
 
-# Reserved for future flags.
 void8
 
-# Vendor-specific values or flags for extended diagnostics and troubleshooting.
 uint16 vendor_specific_status_code
+# Vendor-specific values or flags for extended diagnostics and troubleshooting.
 
 @assert (_offset_ % 8 == {0}) && (_offset_.count == 1) && (_offset_.max / 8 <= 63)  # One CAN FD frame up to this point.
 
 # --------------------------  PER CELL ESTIMATES  --------------------------
 
+float16[<256] cell_voltages  # [volt]
 # Individual cell voltages.
 # The number of elements shall match the number of cells in the battery.
 # If the number of cells is unknown, the array shall be empty.
 # If the number of cells is known, but their voltages cannot be estimated, the elements shall be NaN.
-float16[<256] cell_voltages  # [volt]
 
 @assert _offset_ % 8 == {0}

--- a/regulated/zubax/sensor/bms/Technology.0.1.uavcan
+++ b/regulated/zubax/sensor/bms/Technology.0.1.uavcan
@@ -1,12 +1,10 @@
-#
 # Battery chemistry type and its form-factor. This is a nested type.
-#
 
 void1
 uint7 value
 
 uint7 UNKNOWN = 0
-uint7 OTHER   = 1  # The chemistry type is not specified in this enumeration. Please submit a pull request.
+uint7 OTHER   = 1  # The technology is not specified in this enumeration. Please submit a pull request.
 
 uint7 LI_CO_O2        = 16
 uint7 LI_FE_PO4       = 17

--- a/regulated/zubax/sensor/wattmeter/DCSample.0.1.uavcan
+++ b/regulated/zubax/sensor/wattmeter/DCSample.0.1.uavcan
@@ -1,7 +1,5 @@
-#
 # Generic DC voltage/current sample.
 # Low-pass filtering should be applied to avoid aliasing effects.
-#
 
 uavcan.si.unit.voltage.Scalar.1.0          voltage
 uavcan.si.unit.electric_current.Scalar.1.0 current

--- a/test.py
+++ b/test.py
@@ -68,20 +68,20 @@ for t in output:
         line = line.strip('\r\n')
         abort = partial(die_at, t, index)
 
-        # Check header comment
-        if index == 0 and line != '#':
+        # Check header comment.
+        if index == 0 and line[0] != '#':
             if not any(map(lambda e: t.full_namespace.startswith(e),
                            NAMESPACES_EXEMPTED_FROM_HEADER_COMMENT_REQUIREMENT)):
-                abort('Every data type definition must have a header comment surrounded with "#\\n",',
-                      'unless it is a member of:', NAMESPACES_EXEMPTED_FROM_HEADER_COMMENT_REQUIREMENT)
+                abort('Every data type definition shall have a header comment unless it is a member of:',
+                      NAMESPACES_EXEMPTED_FROM_HEADER_COMMENT_REQUIREMENT)
 
-        # Check trailing comment placement
-        # TODO: this test breaks on string literals containing "#"
+        # Check trailing comment placement.
+        # TODO: this test breaks on string literals containing "#".
         if not line.startswith('#') and '#' in line and '  #' not in line:
-            abort('Trailing line comments must be separated from the preceding text with at least two spaces')
+            abort('Trailing line comments shall be separated from the preceding text with at least two spaces')
 
         if line != '#' and '#' in line and '# ' not in line:
-            abort('The text of a comment must be separated from the comment character with a single space')
+            abort('The text of a comment shall be separated from the comment character with a single space')
 
         if line.endswith(' '):
             abort('Trailing spaces are not permitted')
@@ -96,7 +96,7 @@ for t in output:
                 abort('Disallowed character', repr(char), 'code', ord(char), 'at column', char_index + 1)
 
     if not text.endswith('\n') or text.endswith('\n' * 2):
-        abort('A file must contain exactly one blank line at the end')
+        abort('A file shall contain exactly one blank line at the end')
 
 
 def get_max_bit_length(ty) -> int:

--- a/test.py
+++ b/test.py
@@ -69,7 +69,7 @@ for t in output:
         abort = partial(die_at, t, index)
 
         # Check header comment.
-        if index == 0 and line[0] != '#':
+        if index == 0 and not line.startswith('#'):
             if not any(map(lambda e: t.full_namespace.startswith(e),
                            NAMESPACES_EXEMPTED_FROM_HEADER_COMMENT_REQUIREMENT)):
                 abort('Every data type definition shall have a header comment unless it is a member of:',

--- a/uavcan/diagnostic/32760.Record.1.0.uavcan
+++ b/uavcan/diagnostic/32760.Record.1.0.uavcan
@@ -1,19 +1,17 @@
-#
 # Generic human-readable text message for logging and displaying purposes.
 # Generally, it should be published at the lowest priority level.
-#
 
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 # Optional timestamp in the network-synchronized time system; zero if undefined.
 # The timestamp value conveys the exact moment when the reported event took place.
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 
-# Standard severity, 3 bit wide.
 Severity.1.0 severity
+# Standard severity, 3 bit wide.
 
-# Message text.
-# Normally, messages should be kept as short as possible, especially those of high severity.
 void6
 uint8[<=112] text
+# Message text.
+# Normally, messages should be kept as short as possible, especially those of high severity.
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max <= (124 * 8)     # Two CAN FD frames max

--- a/uavcan/diagnostic/Severity.1.0.uavcan
+++ b/uavcan/diagnostic/Severity.1.0.uavcan
@@ -1,42 +1,40 @@
-#
 # Generic message severity representation.
-#
 
+uint3 value
 # The severity level ranging from 0 to 7, where low values represent low-severity (unimportant) messages, and
 # high values represent high-severity (important) messages. Several mnemonics for the severity levels are
 # defined below. Nodes are advised to implement output filtering mechanisms, allowing users to select
 # the minimal severity for emitted messages; messages of the selected and higher severity levels will
 # be published, and messages of lower severity will be suppressed (discarded).
-uint3 value
 
-# Messages of this severity can be used only during development.
-# They must not be used in a fielded operational system.
 uint3 TRACE = 0
+# Messages of this severity can be used only during development.
+# They shall not be used in a fielded operational system.
 
+uint3 DEBUG = 1
 # Messages that can aid in troubleshooting.
 # Messages of this severity and lower should be disabled by default.
-uint3 DEBUG = 1
 
+uint3 INFO = 2
 # General informational messages of low importance.
 # Messages of this severity and lower should be disabled by default.
-uint3 INFO = 2
 
+uint3 NOTICE = 3
 # General informational messages of high importance.
 # Messages of this severity and lower should be disabled by default.
-uint3 NOTICE = 3
 
+uint3 WARNING = 4
 # Messages reporting abnormalities and warning conditions.
 # Messages of this severity and higher should be enabled by default.
-uint3 WARNING = 4
 
+uint3 ERROR = 5
 # Messages reporting problems and error conditions.
 # Messages of this severity and higher should be enabled by default.
-uint3 ERROR = 5
 
+uint3 CRITICAL = 6
 # Messages reporting serious problems and critical conditions.
 # Messages of this severity and higher should be always enabled.
-uint3 CRITICAL = 6
 
+uint3 ALERT = 7
 # Notifications of dangerous circumstances that demand immediate attention.
 # Messages of this severity should be always enabled.
-uint3 ALERT = 7

--- a/uavcan/file/405.GetInfo.0.1.uavcan
+++ b/uavcan/file/405.GetInfo.0.1.uavcan
@@ -1,28 +1,25 @@
-#
 # Information about a remote file system entry (file, directory, etc).
-#
 
 Path.1.0 path
 
 ---
 
-# Result of the operation
 Error.1.0 error
+# Result of the operation.
 
-# File size in bytes. Should be set to zero for directories.
 truncated uint40 size
+# File size in bytes. Should be set to zero for directories.
 
-# The UNIX Epoch time when the entry was last modified. Zero if unknown.
 truncated uint40 unix_timestamp_of_last_modification
+# The UNIX Epoch time when the entry was last modified. Zero if unknown.
 
-# If such entry does not exist, all flags should be cleared/ignored.
-bool is_file_not_directory  # True if file, false if directory
-bool is_link                # This is a link to another entry; the above flag indicates the type of the target
-bool is_readable            # The item can be read by the caller (applies to files and directories)
-bool is_writeable           # The item can be written by the caller (applies to files and directories)
 void4
+bool is_file_not_directory  # True if file, false if directory.
+bool is_link                # This is a link to another entry; the above flag indicates the type of the target.
+bool is_readable            # The item can be read by the caller (applies to files and directories).
+bool is_writeable           # The item can be written by the caller (applies to files and directories).
+# If such entry does not exist, all flags should be cleared/ignored.
 
-# Reserved for future use
 void64
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/file/406.List.0.1.uavcan
+++ b/uavcan/file/406.List.0.1.uavcan
@@ -1,11 +1,10 @@
-#
 # This service can be used to list a remote directory, one entry per request.
 #
 # The client should query each entry independently, iterating 'entry_index' from 0 until the last entry.
 # When the index reaches the number of elements in the directory, the server will report that there is
 # no such entry by returning an empty name.
 #
-# The field entry_index must be applied to an ordered list of directory entries (e.g. alphabetically ordered).
+# The field entry_index shall be applied to an ordered list of directory entries (e.g. alphabetically ordered).
 # The exact sorting criteria does not matter as long as it provides the same ordering for subsequent service calls.
 #
 # Observe that this listing operation is fundamentally non-atomic. The caller shall beware of possible race conditions
@@ -14,11 +13,10 @@
 # index of the next request, the next returned item (or several, if more items were inserted) will repeat the ones
 # that were listed earlier. The caller should handle that properly, either by ignoring the repeated items or by
 # restarting the listing operation from the beginning (index 0).
-#
 
 uint32 entry_index
 
-void32                  # Reserved for future use
+void32                  # Reserved for future use.
 
 Path.1.0 directory_path
 
@@ -26,8 +24,9 @@ Path.1.0 directory_path
 
 ---
 
-void32                  # Reserved for future use
+void32                  # Reserved for future use.
 
+Path.1.0 entry_base_name
 # The base name of the referenced entry, i.e., relative to the outer directory.
 # The outer directory path is not included to conserve bandwidth.
 # Empty if such entry does not exist.
@@ -35,6 +34,5 @@ void32                  # Reserved for future use
 # For example, suppose there is a file "/foo/bar/baz.bin". Listing the directory with the path "/foo/bar/" (the slash
 # at the end is optional) at the index 0 will return "baz.bin". Listing the same directory at the index 1 (or any
 # higher) will return an empty name "", indicating that the caller has reached the end of the list.
-Path.1.0 entry_base_name
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/file/407.Modify.1.0.uavcan
+++ b/uavcan/file/407.Modify.1.0.uavcan
@@ -1,4 +1,3 @@
-#
 # Manipulate a remote file system entry. Applies to files, directories, and links alike.
 # If the remote entry is a directory, all nested entries will be affected, too.
 #
@@ -32,7 +31,6 @@
 #   Specify the source path (file/directory/link) and make the destination path empty.
 #   Fails if the path does not exist.
 #   Flags are ignored.
-#
 
 bool preserve_source            # Do not remove the source. Used to copy instead of moving.
 bool overwrite_destination      # If the destination exists, remove it beforehand.

--- a/uavcan/file/408.Read.1.0.uavcan
+++ b/uavcan/file/408.Read.1.0.uavcan
@@ -1,4 +1,3 @@
-#
 # Read file from a remote node.
 #
 # There are two possible outcomes of a successful call:
@@ -16,7 +15,7 @@
 # application designers are recommended to adhere to the following convention. Let every file whose integrity
 # is of interest have a hash or a digital signature, which is stored in an adjacent file under the same name
 # suffixed with the appropriate extension according to the type of hash or digital signature used.
-# For example, let there be file "image.bin", integrity of which must be ensured by the client upon downloading.
+# For example, let there be file "image.bin", integrity of which shall be ensured by the client upon downloading.
 # Suppose that the file is hashed using SHA-256, so the appropriate file extension for the hash would be
 # ".sha256". Following this convention, the hash of "image.bin" would be stored in "image.bin.sha256".
 # After downloading the file, the client would read the hash (being small, the hash can be read in a single
@@ -27,7 +26,6 @@
 # in that case, hash/signature should be pre-computed and stored in a real file. If this approach is followed,
 # implementers are advised to use only SHA-256 for hashing, in order to reduce the number of fielded
 # incompatible implementations.
-#
 
 truncated uint40 offset
 

--- a/uavcan/file/409.Write.1.0.uavcan
+++ b/uavcan/file/409.Write.1.0.uavcan
@@ -1,4 +1,3 @@
-#
 # Write into a remote file.
 # The server shall place the contents of the field 'data' into the file pointed by 'path' at the offset specified by
 # the field 'offset'.
@@ -9,7 +8,6 @@
 # transfer is finished.
 #
 # When the write operation is complete, the server shall truncate the resulting file past the specified offset.
-#
 
 truncated uint40 offset
 

--- a/uavcan/file/Error.1.0.uavcan
+++ b/uavcan/file/Error.1.0.uavcan
@@ -1,7 +1,5 @@
-#
 # Nested type.
 # Result of a file system operation.
-#
 
 uint16 OK                = 0
 uint16 UNKNOWN_ERROR     = 65535

--- a/uavcan/file/Path.1.0.uavcan
+++ b/uavcan/file/Path.1.0.uavcan
@@ -1,4 +1,3 @@
-#
 # Nested type.
 # A file system path encoded in UTF8. The only valid separator is the forward slash "/".
 # A single slash ("/") refers to the root directory (the location of which is defined by the server).
@@ -10,7 +9,6 @@
 # The maximum path length limit is chosen as a trade-off between compatibility with deep directory structures and
 # the worst-case transfer length. The limit is 112 bytes, which allows all transfers containing a single instance
 # of path and no other large data chunks to fit into two CAN FD frames.
-#
 
 uint8 SEPARATOR = '/'
 uint8 MAX_LENGTH = 112

--- a/uavcan/internet/udp/32750.OutgoingPacket.0.1.uavcan
+++ b/uavcan/internet/udp/32750.OutgoingPacket.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # This message carries UDP packets from a node on the local bus to a remote host on the Internet or a LAN.
 #
 # Any node can broadcast a message of this type.
@@ -28,7 +27,7 @@
 #
 # Applications are free to choose whatever redundancy management strategy works best for them.
 #
-# If the source node expects that the remote host will send some data back, it must explicitly notify
+# If the source node expects that the remote host will send some data back, it shall explicitly notify
 # the modem nodes about this, so that they could prepare to perform reverse forwarding when the
 # expected data arrives from the remote host. The technique of reverse forwarding is known in
 # networking as IP Masquerading, or (in general) Network Address Translation (NAT). The notification
@@ -89,22 +88,23 @@
 # in order to avoid interference with a real-time traffic on the bus. Usage of higher priority levels is
 # unlikely to be practical because the latency and throughput limitations introduced by the on-board radio
 # communication equipment are likely to vastly exceed those of the local CAN bus.
-#
 
+uint32 NAT_ENTRY_MIN_TTL = 24 * 60 * 60  # [second]
 # Modem nodes are required to keep the NAT table entries alive for at least this amount of time, unless the
 # table is overflowed, in which case they are allowed to remove least recently used entries in favor of
 # newer ones. Modem nodes are required to be able to accommodate at least 100 entries in the NAT table.
-uint32 NAT_ENTRY_MIN_TTL = 24 * 60 * 60  # [second]
 
+uint16 session_id
 # This field is set to an arbitrary value by the transmitting node in order to be able to match the response
 # with the locally kept context. The function of this field is virtually identical to that of UDP/IP port
 # numbers. This value can be set to zero safely if the sending node does not have multiple contexts to
 # distinguish between.
-uint16 session_id
 
-# UDP destination port number.
 uint16 destination_port
+# UDP destination port number.
 
+void2
+uint8[<=45] destination_address
 # Domain name or IP address where the payload should be forwarded to.
 # Note that broadcast addresses are allowed here, for example, 255.255.255.255.
 # Broadcasting with masquerading enabled works the same way as unicasting with masquerading enabled: the modem
@@ -119,21 +119,19 @@ uint16 destination_port
 #   "2001:0db8:85a3:0000:0000:8a2e:0370:7334"       - IPv6 address, full form
 #   "2001:db8:85a3::8a2e:370:7334"                  - IPv6 address, same as above, short form (preferred)
 #   "ABCD:ABCD:ABCD:ABCD:ABCD:ABCD:192.168.158.190" - IPv4-mapped IPv6, full form (length limit, 45 characters)
-void2
-uint8[<=45] destination_address
 
 @assert _offset_ % 8 == {0}
 
-# Option flags.
+void5
 bool use_masquerading   # Expect data back (i.e., instruct the modem to use the NAT table).
 bool use_dtls           # Use Datagram Transport Layer Security. Drop the packet if DTLS is not supported.
-void5
+# Option flags.
 
+uint8[<=261] payload
 # Effective payload. This data will be forwarded to the remote host verbatim.
 # UDP packets that contain more than 508 bytes of payload may be dropped by some types of
 # communication equipment. Refer to RFC 791 and 2460 for an in-depth review.
 # UAVCAN further limits the maximum packet size to reduce the memory and traffic burden on the nodes.
-uint8[<=261] payload
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max / 8 == 313

--- a/uavcan/internet/udp/500.HandleIncomingPacket.0.1.uavcan
+++ b/uavcan/internet/udp/500.HandleIncomingPacket.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # This message carries UDP packets sent from a remote host on the Internet or a LAN to a node on the local UAVCAN bus.
 # Please refer to the definition of the message type OutgoingPacket for a general overview of the packet forwarding
 # logic.
@@ -6,7 +5,9 @@
 # This data type has been made a service type rather than a message type in order to make its transfers addressable,
 # allowing nodes to employ hardware acceptance filters for filtering out forwarded datagrams that are not addressed
 # to them. Additionally, requiring the destination nodes to always respond upon reception of the forwarded datagram
-# opens interesting opportunities for future extensions of the forwarding protocol.
+# opens interesting opportunities for future extensions of the forwarding protocol. If the service invocation times
+# out, the modem node is permitted to remove the corresponding entry from the NAT table immediately, not waiting
+# for its TTL to expire.
 #
 # It should be noted that this data type definition intentionally leaves out the source address. This is done in
 # order to simplify the implementation, reduce the bus traffic overhead, and because the nature of the
@@ -25,27 +26,23 @@
 # node to implement additional logic, which may be undesirable. Therefore, implementers are free to deviate from
 # this recommendation and resort to a fixed priority level instead. In the case of a fixed priority level, it is
 # advised to use the lowest transfer priority level.
-#
 
-# This field must contain the same value that was used by the local node when sending the corresponding outgoing
+uint16 session_id
+# This field shall contain the same value that was used by the local node when sending the corresponding outgoing
 # packet using the message type OutgoingPacket. This value will be used by the local node to match the response
 # with its local context.
-uint16 session_id
 
+void7
+uint8[<=309] payload
 # Effective payload. This data will be forwarded from the remote host verbatim.
 # UDP packets that contain more than 508 bytes of payload may be dropped by some types of
 # communication equipment. Refer to RFC 791 and 2460 for an in-depth review.
 # UAVCAN further limits the maximum packet size to reduce the memory and traffic burden on the nodes.
 # Datagrams that exceed the capacity of this field should be discarded by the modem node.
-void7
-uint8[<=309] payload
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max == (313 * 8)     # At most five CAN FD frames
 
 ---
 
-# If the service invocation times out, the modem node is permitted to remove the corresponding entry from
-# the NAT table immediately, not waiting for its TTL to expire.
-
-void56      # Reserved for future use.
+void56

--- a/uavcan/metatransport/can/ArbitrationID.0.1.uavcan
+++ b/uavcan/metatransport/can/ArbitrationID.0.1.uavcan
@@ -1,6 +1,4 @@
-#
 # CAN frame arbitration field.
-#
 
 @union
 

--- a/uavcan/metatransport/can/BaseArbitrationID.0.1.uavcan
+++ b/uavcan/metatransport/can/BaseArbitrationID.0.1.uavcan
@@ -1,6 +1,4 @@
-#
 # 11-bit identifier.
-#
 
 truncated uint11 value
 void18

--- a/uavcan/metatransport/can/DataClassic.0.1.uavcan
+++ b/uavcan/metatransport/can/DataClassic.0.1.uavcan
@@ -1,6 +1,4 @@
-#
 # Classic data frame payload.
-#
 
 ArbitrationID.0.1 arbitration_id
 void4

--- a/uavcan/metatransport/can/DataFD.0.1.uavcan
+++ b/uavcan/metatransport/can/DataFD.0.1.uavcan
@@ -1,6 +1,4 @@
-#
 # CAN FD data frame payload.
-#
 
 ArbitrationID.0.1 arbitration_id
 void1

--- a/uavcan/metatransport/can/Error.0.1.uavcan
+++ b/uavcan/metatransport/can/Error.0.1.uavcan
@@ -1,5 +1,3 @@
-#
 # CAN bus error report: either an intentionally generated error frame or a disturbance.
-#
 
 void30

--- a/uavcan/metatransport/can/ExtendedArbitrationID.0.1.uavcan
+++ b/uavcan/metatransport/can/ExtendedArbitrationID.0.1.uavcan
@@ -1,5 +1,3 @@
-#
 # 29-bit identifier.
-#
 
 truncated uint29 value

--- a/uavcan/metatransport/can/Frame.0.1.uavcan
+++ b/uavcan/metatransport/can/Frame.0.1.uavcan
@@ -1,6 +1,4 @@
-#
 # CAN 2.0 or CAN FD frame representation. This is the top-level data type in its namespace.
-#
 
 uavcan.time.SynchronizedTimestamp.1.0 timestamp
 

--- a/uavcan/metatransport/can/Manifestation.0.1.uavcan
+++ b/uavcan/metatransport/can/Manifestation.0.1.uavcan
@@ -1,6 +1,4 @@
-#
 # CAN frame properties that can be manifested on the bus.
-#
 
 @union
 

--- a/uavcan/metatransport/can/RTR.0.1.uavcan
+++ b/uavcan/metatransport/can/RTR.0.1.uavcan
@@ -1,5 +1,3 @@
-#
 # Classic remote transmission request (not defined for CAN FD).
-#
 
 ArbitrationID.0.1 arbitration_id

--- a/uavcan/metatransport/serial/Fragment.0.1.uavcan
+++ b/uavcan/metatransport/serial/Fragment.0.1.uavcan
@@ -1,7 +1,5 @@
-#
 # A chunk of raw bytes exchanged over a serial transport. Serial links do not support framing natively.
 # The chunk may be of arbitrary size.
-#
 
 uavcan.time.SynchronizedTimestamp.1.0 timestamp
 

--- a/uavcan/metatransport/udp/Endpoint.0.1.uavcan
+++ b/uavcan/metatransport/udp/Endpoint.0.1.uavcan
@@ -1,17 +1,15 @@
-#
 # A UDP/IP endpoint address specification.
-#
 
+uint8[16] ip_address
 # The IP address of the host in the network byte order (big endian).
 # IPv6 addresses are represented as-is.
 # IPv4 addresses are represented using IPv4-mapped IPv6 addresses.
-uint8[16] ip_address
 
-# MAC address of the host in the network byte order (big endian).
 uint8[6] mac_address
+# MAC address of the host in the network byte order (big endian).
 
-# The UDP port number.
 uint16 port
+# The UDP port number.
 
 void64
 

--- a/uavcan/metatransport/udp/Frame.0.1.uavcan
+++ b/uavcan/metatransport/udp/Frame.0.1.uavcan
@@ -1,9 +1,7 @@
-#
 # A generic UDP/IP frame.
 # Jumboframes are supported in the interest of greater application compatibility.
 #
 # pragma: no-bit-length-limit
-#
 
 uavcan.time.SynchronizedTimestamp.1.0 timestamp
 
@@ -15,8 +13,7 @@ Endpoint.0.1 destination
 
 @assert _offset_ % 64 == {0}
 
-# Max jumbo frame 9 KiB, IP header min 20 B, UDP header 8 B.
-uint14 MTU = 1024 * 9 - 20 - 8
+uint14 MTU = 1024 * 9 - 20 - 8  # Max jumbo frame 9 KiB, IP header min 20 B, UDP header 8 B.
 void2
 uint8[<=MTU] data
 

--- a/uavcan/node/32085.Heartbeat.1.0.uavcan
+++ b/uavcan/node/32085.Heartbeat.1.0.uavcan
@@ -1,6 +1,5 @@
-#
 # Abstract node status information.
-# This is the only high-level function that must be implemented by all nodes.
+# This is the only high-level function that shall be implemented by all nodes.
 #
 # All UAVCAN nodes that have a node-ID are required to publish this message periodically.
 # Nodes that do not have a node-ID (also known as "anonymous nodes") shall not publish this message.
@@ -8,40 +7,39 @@
 # The default subject ID 32085 is 111110101010101 in binary. The alternating bit pattern at the end
 # helps transceiver synchronization (e.g., on CAN-based networks) and on some transports permits
 # automatic bit rate detection.
-#
 
-# The publication period must not exceed this limit.
-# The period should not change while the node is running.
 uint16 MAX_PUBLICATION_PERIOD = 1   # [second]
+# The publication period shall not exceed this limit.
+# The period should not change while the node is running.
 
-# If the last message from the node was received more than this amount of time ago, it should be considered offline.
 uint16 OFFLINE_TIMEOUT = 3          # [second]
+# If the last message from the node was received more than this amount of time ago, it should be considered offline.
 
+uint32 uptime                       # [second]
 # The uptime seconds counter should never overflow. The counter will reach the upper limit in ~136 years,
 # upon which time it should stay at 0xFFFFFFFF until the node is restarted.
-#
 # Other nodes may detect that a remote node has restarted when this value leaps backwards.
-uint32 uptime                       # [second]
 
+truncated uint2 health
 # Abstract node health information. See constants below.
 # Follows:
 #   https://www.law.cornell.edu/cfr/text/14/23.1322
 #   https://www.faa.gov/documentLibrary/media/Advisory_Circular/AC_25.1322-1.pdf section 6
-truncated uint2 health
 
-# The node is functioning properly (nominal).
 uint2 HEALTH_NOMINAL  = 0
+# The node is functioning properly (nominal).
 
+uint2 HEALTH_ADVISORY = 1
 # A critical parameter went out of range or the node encountered a minor failure that does not prevent
 # the subsystem from performing any of its real-time functions.
-uint2 HEALTH_ADVISORY = 1
 
-# The node encountered a major failure and is performing in a degraded mode or outside of its designed limitations.
 uint2 HEALTH_CAUTION  = 2
+# The node encountered a major failure and is performing in a degraded mode or outside of its designed limitations.
 
-# The node suffered a fatal malfunction and is unable to perform its intended function.
 uint2 HEALTH_WARNING  = 3
+# The node suffered a fatal malfunction and is unable to perform its intended function.
 
+truncated uint3 mode
 # The current operating mode. See constants below.
 #
 # The mode OFFLINE can be used for informing other network participants that the sending node has ceased its
@@ -49,25 +47,24 @@ uint2 HEALTH_WARNING  = 3
 # expire before detecting that the sending node is no longer available.
 #
 # Reserved values can be used in future revisions of the specification.
-truncated uint3 mode
 
-# Normal operating mode.
 uint3 MODE_OPERATIONAL      = 0
+# Normal operating mode.
 
-# Initialization is in progress; this mode is entered immediately after startup.
 uint3 MODE_INITIALIZATION   = 1
+# Initialization is in progress; this mode is entered immediately after startup.
 
-# E.g. calibration, self-test, etc.
 uint3 MODE_MAINTENANCE      = 2
+# E.g. calibration, self-test, etc.
 
-# New software/firmware is being loaded or the bootloader is running.
 uint3 MODE_SOFTWARE_UPDATE  = 3
+# New software/firmware is being loaded or the bootloader is running.
 
-# The node is no longer available.
 uint3 MODE_OFFLINE          = 7
+# The node is no longer available.
 
-# Optional, vendor-specific node status code, e.g. a fault code or a status bitmask.
 truncated uint19 vendor_specific_status_code
+# Optional, vendor-specific node status code, e.g. a fault code or a status bitmask.
 
 @assert _offset_ % 8 == {0}
-@assert _offset_.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)
+@assert _offset_.max <= 56    # Shall fit into one CAN 2.0 frame (least capable transport, smallest MTU)

--- a/uavcan/node/430.GetInfo.1.0.uavcan
+++ b/uavcan/node/430.GetInfo.1.0.uavcan
@@ -1,46 +1,46 @@
-#
 # Full node info request.
-# All of the returned information must be static (unchanged) while the node is running.
+# All of the returned information shall be static (unchanged) while the node is running.
 # It is highly recommended to support this service on all nodes.
-#
 
 ---
 
+Version.1.0 protocol_version
 # The UAVCAN protocol version implemented on this node, both major and minor.
 # Not to be changed while the node is running.
-Version.1.0 protocol_version
 
-# The version information must not be changed while the node is running.
-# The correct hardware version must be reported at all times, excepting software-only nodes, in which
+Version.1.0 hardware_version
+Version.1.0 software_version
+# The version information shall not be changed while the node is running.
+# The correct hardware version shall be reported at all times, excepting software-only nodes, in which
 # case it should be set to zeros.
 # If the node is equipped with a UAVCAN-capable bootloader, the bootloader should report the software
 # version of the installed application, if there is any; if no application is found, zeros should be reported.
-Version.1.0 hardware_version
-Version.1.0 software_version
 
+uint64 software_vcs_revision_id
 # A version control system (VCS) revision number or hash. Not to be changed while the node is running.
 # For example, this field can be used for reporting the short git commit hash of the current
 # software revision.
 # Set to zero if not used.
-uint64 software_vcs_revision_id
 
+uint8[16] unique_id
 # The unique node ID is a 128-bit long sequence that is likely to be globally unique per node.
-# The vendor must ensure that the probability of a collision with any other node UID globally is negligibly low.
+# The vendor shall ensure that the probability of a collision with any other node UID globally is negligibly low.
 # UID is defined once per hardware unit and should never be changed.
 # All zeros is not a valid UID.
-# If the node is equipped with a UAVCAN-capable bootloader, the bootloader must use the same UID.
-uint8[16] unique_id
+# If the node is equipped with a UAVCAN-capable bootloader, the bootloader shall use the same UID.
 
-# Manual serialization note: only fixed-size fields up to this point. The following fields are dynamically sized.
 @assert _offset_ == {30 * 8}
+# Manual serialization note: only fixed-size fields up to this point. The following fields are dynamically sized.
 
-# Human-readable non-empty ASCII node name. An empty name is not permitted.
-# The name must not be changed while the node is running.
-# Allowed characters are: a-z (lowercase ASCII letters) 0-9 (decimal digits) . (dot) - (dash) _ (underscore).
-# Node name is a reversed Internet domain name (like Java packages), e.g. "com.manufacturer.project.product".
 void2
 uint8[<=50] name
+# Human-readable non-empty ASCII node name. An empty name is not permitted.
+# The name shall not be changed while the node is running.
+# Allowed characters are: a-z (lowercase ASCII letters) 0-9 (decimal digits) . (dot) - (dash) _ (underscore).
+# Node name is a reversed Internet domain name (like Java packages), e.g. "com.manufacturer.project.product".
 
+void7
+uint64[<=1] software_image_crc
 # The value of an arbitrary hash function applied to the software image. Not to be changed while the node is running.
 # This field can be used to detect whether the software or firmware running on the node is an exact
 # same version as a certain specific revision. This field provides a very strong identity guarantee,
@@ -55,13 +55,11 @@ uint8[<=50] name
 #     the hash function becomes ill-defined, because it becomes recursively dependent on itself.
 #     In order to circumvent this issue, while computing or checking the CRC, its value stored
 #     within the image should be zeroed out.
-void7
-uint64[<=1] software_image_crc
 
+uint8[<=222] certificate_of_authenticity
 # The certificate of authenticity (COA) of the node, 222 bytes max, optional. This field can be used for
 # reporting digital signatures (e.g., RSA-1776, or ECDSA if a higher degree of cryptographic strength is desired).
 # Leave empty if not used. Not to be changed while the node is running.
-uint8[<=222] certificate_of_authenticity
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max == (313 * 8)     # At most five CAN FD frames

--- a/uavcan/node/434.GetTransportStatistics.0.1.uavcan
+++ b/uavcan/node/434.GetTransportStatistics.0.1.uavcan
@@ -1,24 +1,22 @@
-#
 # Returns a set of general low-level transport statistical counters.
 # Servers are encouraged but not required to sample the data atomically.
-#
 
 ---
 
-# UAVCAN supports up to triply modular redundant interfaces.
 uint8 MAX_NETWORK_INTERFACES = 3
+# UAVCAN supports up to triply modular redundant interfaces.
 
+IOStatistics.0.1 transfer_statistics
 # UAVCAN transfer performance statistics:
 # the number of UAVCAN transfers successfully sent, successfully received, and failed.
 # The methods of error counting are implementation-defined.
-IOStatistics.0.1 transfer_statistics
 
+void6
+IOStatistics.0.1[<=MAX_NETWORK_INTERFACES] network_interface_statistics
 # Network interface statistics, separate per interface.
 # E.g., for a doubly redundant transport, this array would contain two elements,
 # the one at the index zero would apply to the first interface, the other to the second interface.
 # The methods of counting are implementation-defined.
-void6
-IOStatistics.0.1[<=MAX_NETWORK_INTERFACES] network_interface_statistics
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max <= (63 * 8)      # One CAN FD frame

--- a/uavcan/node/435.ExecuteCommand.1.0.uavcan
+++ b/uavcan/node/435.ExecuteCommand.1.0.uavcan
@@ -1,20 +1,19 @@
-#
 # Instructs the server node to execute or commence execution of a simple predefined command.
 # All standard commands are optional; i.e., not guaranteed to be supported by all nodes.
-#
 
+uint16 command
 # Standard pre-defined commands are at the top of the range (defined below).
 # Vendors can define arbitrary, vendor-specific commands in the bottom part of the range (starting from zero).
-# Vendor-specific commands must not use identifiers above 32767.
-uint16 command
+# Vendor-specific commands shall not use identifiers above 32767.
 
+uint16 COMMAND_RESTART = 65535
 # Reboot the node.
 # Note that some standard commands may or may not require a restart in order to take effect; e.g., factory reset.
-uint16 COMMAND_RESTART = 65535
 
-# Shut down the node; further access will not be possible until the power is turned back on.
 uint16 COMMAND_POWER_OFF = 65534
+# Shut down the node; further access will not be possible until the power is turned back on.
 
+uint16 COMMAND_BEGIN_SOFTWARE_UPDATE = 65533
 # Begin the software update process using uavcan.file.Read. This command makes use of the "parameter" field below.
 # The parameter contains the path to the new software image file to be downloaded by the server from the client
 # using the standard service uavcan.file.Read. Observe that this operation swaps the roles of the client and
@@ -46,36 +45,34 @@ uint16 COMMAND_POWER_OFF = 65534
 # It is also recognized that in a microcontroller setting, the application that served the update request will have
 # to pass the update-related metadata (such as the node ID of the server and the firmware image file path) to
 # the embedded bootloader. The tactics of that transaction lie outside of the scope of this specification.
-uint16 COMMAND_BEGIN_SOFTWARE_UPDATE = 65533
 
+uint16 COMMAND_FACTORY_RESET = 65532
 # Return the node's configuration back to the factory default settings (may require restart).
 # Due to the uncertainty whether a restart is required, generic interfaces should always force a restart.
-uint16 COMMAND_FACTORY_RESET = 65532
 
+uint16 COMMAND_EMERGENCY_STOP = 65531
 # Cease activities immediately, enter a safe state until restarted.
 # Further operation may no longer be possible until a restart command is executed.
-uint16 COMMAND_EMERGENCY_STOP = 65531
 
+uint16 COMMAND_STORE_PERSISTENT_STATES = 65530
 # This command instructs the node to store the current configuration parameter values and other persistent states
 # to the non-volatile storage. Nodes are allowed to manage persistent states automatically, obviating the need for
 # this command by committing all such data to the non-volatile memory automatically as necessary. However, some
 # nodes may lack this functionality, in which case this parameter should be used. Generic interfaces should always
 # invoke this command in order to ensure that the data is stored even if the node doesn't implement automatic
 # persistence management.
-uint16 COMMAND_STORE_PERSISTENT_STATES = 65530
 
+void1
+uint8[<=uavcan.file.Path.1.0.MAX_LENGTH] parameter
 # A string parameter supplied to the command. The format and interpretation is command-specific.
 # The standard commands do not use this field (ignore it), excepting the following:
 #   - COMMAND_BEGIN_SOFTWARE_UPDATE
-void1
-uint8[<=uavcan.file.Path.1.0.MAX_LENGTH] parameter
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max <= (124 * 8)     # Two CAN FD frames max
 
 ---
 
-# The result of the request.
 uint8 STATUS_SUCCESS        = 0     # Started or executed successfully
 uint8 STATUS_FAILURE        = 1     # Could not start or the desired outcome could not be reached
 uint8 STATUS_NOT_AUTHORIZED = 2     # Denied due to lack of authorization
@@ -84,6 +81,6 @@ uint8 STATUS_BAD_PARAMETER  = 4     # The supplied parameter cannot be used with
 uint8 STATUS_BAD_STATE      = 5     # The current state of the node does not permit execution of this command
 uint8 STATUS_INTERNAL_ERROR = 6     # The operation should have succeeded but an unexpected failure occurred
 uint8 status
+# The result of the request.
 
-# Reserved for future use
 void48

--- a/uavcan/node/ID.1.0.uavcan
+++ b/uavcan/node/ID.1.0.uavcan
@@ -1,9 +1,7 @@
-#
 # Defines a node-ID.
 # The maximum valid value is dependent on the underlying transport layer.
 # Values lower than 128 are always valid for all transports.
 # Refer to the specification for more info.
-#
 
 uint16 value
 

--- a/uavcan/node/IOStatistics.0.1.uavcan
+++ b/uavcan/node/IOStatistics.0.1.uavcan
@@ -1,18 +1,16 @@
-#
 # A standard set of generic input/output statistical counters that generally should not overflow.
 # If a 40-bit counter is incremented every millisecond, it will overflow in ~35 years.
 # If an overflow occurs, the value will wrap over to zero.
 #
 # The values should not be reset while the node is running.
-#
 
-# The number of successfully emitted entities.
 truncated uint40 num_emitted
+# The number of successfully emitted entities.
 
-# The number of successfully received entities.
 truncated uint40 num_received
+# The number of successfully received entities.
 
+truncated uint40 num_errored
 # How many errors have occurred.
 # The exact definition of "error" and how they are counted are implementation-defined,
 # unless specifically defined otherwise.
-truncated uint40 num_errored

--- a/uavcan/node/Version.1.0.uavcan
+++ b/uavcan/node/Version.1.0.uavcan
@@ -1,7 +1,5 @@
-#
 # A shortened semantic version representation: only major and minor.
 # The protocol generally does not concern itself with the patch version.
-#
 
 uint8 major
 uint8 minor

--- a/uavcan/node/port/431.List.0.1.uavcan
+++ b/uavcan/node/port/431.List.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # Returns a subset of all ports of the specified kind (subject or service) on the remote node.
 # As the number of ports may exceed the capacity of the output array, the server will return only those which are
 # not less than the number specified in the request. The caller should sweep the lower boundary upwards until
@@ -22,7 +21,7 @@
 # The server is REQUIRED to ensure that every element in the returned array is unique.
 #
 # The server is REQUIRED to ensure that by performing the above actions the client will end up with a full set of
-# port-IDs, assuming that the set is not modified between invocations. This implicitly requires that there must be
+# port-IDs, assuming that the set is not modified between invocations. This implicitly requires that there shall be
 # no port-ID that is lower than the greatest value in the returned array that is not listed in the array, because
 # in that case the client will never be able to obtain that value.
 #
@@ -31,7 +30,6 @@
 #
 # For services, server ports shall be returned. Whether client ports are returned is implementation-defined.
 # As in the case of subjects, further differentiation is possible via GetInfo.
-#
 
 ID.1.0 port_id_lower_boundary
 
@@ -39,7 +37,6 @@ ID.1.0 port_id_lower_boundary
 
 ---
 
-# See above for the full description of the logic.
-uint16[<=128] port_ids
+uint16[<=128] port_ids  # See above for the full description of the logic.
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/node/port/432.GetInfo.0.1.uavcan
+++ b/uavcan/node/port/432.GetInfo.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # This service is used to obtain information about a port (either subject or service).
 # It can be used for advanced network inspections, e.g., for building computational graph maps.
 #
@@ -9,15 +8,16 @@
 # The reason client ports are treated differently is due to their inherent volatility: services are often
 # invoked ad-hoc, and the network stack on the client node may choose to reclaim the resources allocated for
 # a client port that is no longer in use for other needs.
-#
 
-# The port of interest; can be either a service or a subject.
-ID.1.0 port_id
+ID.1.0 port_id  # The port of interest; can be either a service or a subject.
 
 @assert _offset_ == {16}
 
 ---
 
+void6
+bool is_input       # Subscriber or server
+bool is_output      # Publisher or client
 # For subject ports, "input" means subscriber and "output" means publisher.
 # A subject port may be both subscriber and publisher at the same time.
 #
@@ -30,19 +30,15 @@ ID.1.0 port_id
 # --------------+---------------+----------------
 #   Subject     | Subscriber    | Publisher
 #   Service     | Server        | Client
-#
-bool is_input       # Subscriber or server
-bool is_output      # Publisher or client
-void6
 
+void2
+uint8[<=50] data_type_full_name
 # If such port exists, this field shall contain the full name of its data type.
 # If the requested port does not exist, this field shall be empty.
 # If this field is empty, the caller should ignore all other fields.
-void2
-uint8[<=50] data_type_full_name
 
+uavcan.node.Version.1.0 data_type_version
 # The version numbers of the data type used at this port.
 # Zeros if the port does not exist.
-uavcan.node.Version.1.0 data_type_version
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/node/port/433.GetStatistics.0.1.uavcan
+++ b/uavcan/node/port/433.GetStatistics.0.1.uavcan
@@ -1,15 +1,13 @@
-#
 # This service is used to obtain statistical metrics of a port (either message or service).
 # It can be used for advanced network inspections, e.g. for building real-time traffic maps.
-#
 
-# The port of interest; can be either a service or a message.
-ID.1.0 port_id
+ID.1.0 port_id  # The port of interest; can be either a service or a message.
 
 @assert _offset_ == {16}
 
 ---
 
+uavcan.node.IOStatistics.0.1 statistics
 # For messages, "emitted" applies to publications, and "received" applies to subscribers.
 #
 # For services, "emitted" applies to responses, and "received" applies to requests. Normally, they
@@ -26,6 +24,5 @@ ID.1.0 port_id
 # call was processed properly, but the application could not act upon that data, it should not be
 # reported here because that problem should be attributed to a different level of abstraction.
 # The exact definition of an error and the methods of their counting are implementation-defined.
-uavcan.node.IOStatistics.0.1 statistics
 
 @assert _offset_ == {15 * 8}      # 15 bytes max; this service is optimized for high-frequency polling

--- a/uavcan/node/port/ID.1.0.uavcan
+++ b/uavcan/node/port/ID.1.0.uavcan
@@ -1,7 +1,5 @@
-#
 # Used to refer either to a Service or to a Subject.
 # The chosen tag identifies the kind of the port, then the numerical ID identifies the port within the kind.
-#
 
 @union
 SubjectID.1.0 subject_id

--- a/uavcan/node/port/ServiceID.1.0.uavcan
+++ b/uavcan/node/port/ServiceID.1.0.uavcan
@@ -1,6 +1,4 @@
-#
 # Service-ID. The ranges are defined by the specification.
-#
 
 uint9 MAX_UNREGULATED_ID = 127
 

--- a/uavcan/node/port/SubjectID.1.0.uavcan
+++ b/uavcan/node/port/SubjectID.1.0.uavcan
@@ -1,8 +1,6 @@
-#
 # Subject-ID. The ranges are defined by the specification.
-#
 
-uint16 MAX_UNREGULATED_ID = 24575
+uint15 MAX_UNREGULATED_ID = 24575
 
 uint15 value
 

--- a/uavcan/pnp/32741.NodeIDAllocationData.0.1.uavcan
+++ b/uavcan/pnp/32741.NodeIDAllocationData.0.1.uavcan
@@ -1,5 +1,4 @@
-#
-# In order to be able to operate in a UAVCAN network, a node must have a node-ID that is unique within the network.
+# In order to be able to operate in a UAVCAN network, a node shall have a node-ID that is unique within the network.
 # Typically, a valid node-ID can be configured manually for each node; however, in certain use cases the manual
 # approach is either undesirable or impossible, therefore UAVCAN defines the high-level feature of plug-and-play
 # nodes that allows nodes to obtain a node-ID value automatically upon connection to the network. When combined
@@ -15,7 +14,7 @@
 # layer specification for details.
 #
 # An allocated node-ID should not be persistent. This means that if a node is configured to use plug-and-play node-ID
-# allocation, it must perform a new allocation every time it is started or rebooted. The allocated node-ID value
+# allocation, it shall perform a new allocation every time it is started or rebooted. The allocated node-ID value
 # should not be stored on the node itself, because there exist edge cases that may lead to node-ID conflicts under
 # certain circumstances (reviewed later).
 #
@@ -39,10 +38,10 @@
 #   - Five allocators, it is the same as the three allocator configuration reviewed above except that the network
 #     can tolerate the loss of two allocators and still continue to serve allocation requests.
 #
-# In order to get a PnP node-ID, an allocatee must have a globally unique 128-bit integer identifier, known as
+# In order to get a PnP node-ID, an allocatee shall have a globally unique 128-bit integer identifier, known as
 # unique-ID (where "globally unique" means that the probability of having two nodes anywhere in the world that share
 # the same unique-ID is negligibly low). This is the same value that is used in the field unique_id of the data type
-# uavcan.node.GetInfo. All PnP nodes must support the service uavcan.node.GetInfo, and they must use the same
+# uavcan.node.GetInfo. All PnP nodes shall support the service uavcan.node.GetInfo, and they shall use the same
 # unique-ID value when requesting node-ID allocation and when responding to the GetInfo requests (there may exist
 # other usages of the unique-ID value, but they lie outside of the scope of the PnP protocol).
 #
@@ -75,7 +74,7 @@
 # Due to the possibility of coexistence of static nodes with PnP nodes, allocators are tasked with monitoring
 # the nodes present in the network. If the allocator detects an online node in the network the node-ID of which is
 # not found in the allocation table (or the local copy thereof in the case of redundant allocators), the allocator
-# must create a new mock entry where the node-ID matches that of the newly detected node and the unique-ID is set to
+# shall create a new mock entry where the node-ID matches that of the newly detected node and the unique-ID is set to
 # zero (i.e., a 128-bit long sequence of zero bits). This behavior ensures that PnP nodes will never be granted
 # node-ID values that are already taken by static nodes. Allocators are allowed to request the true unique-ID of the
 # newly detected nodes by issuing requests uavcan.node.GetInfo instead of using mock zero unique-IDs, but this is not
@@ -84,7 +83,7 @@
 # this task due to the intrinsic properties of the distributed consensus algorithm; please refer to the documentation
 # for the data type uavcan.pnp.cluster.AppendEntries for more information.
 #
-# The unique-ID & node-ID pair of each allocator must be kept in the allocation table as well. It is allowed to replace
+# The unique-ID & node-ID pair of each allocator shall be kept in the allocation table as well. It is allowed to replace
 # the unique-ID values of allocators with zeros at the discretion of the implementer.
 #
 # As can be inferred from the above, the process of PnP node-ID allocation involves up to two types of communications:
@@ -141,10 +140,10 @@
 #
 # Generally, the randomly chosen values of the request period (Trequest) should be in the range from 0 to 1 seconds.
 # Applications that are not concerned about the allocation time are recommended to pick higher values, as it will
-# reduce interference with other nodes where faster allocations may be desirable. The random interval must be chosen
+# reduce interference with other nodes where faster allocations may be desirable. The random interval shall be chosen
 # anew per transmission, whereas the pseudo node-ID value is allowed to stay constant per node.
 #
-# The source of random data for Trequest must be likely to yield different values for participating nodes, avoiding
+# The source of random data for Trequest shall be likely to yield different values for participating nodes, avoiding
 # common sequences. This implies that the time since boot alone is not a sufficiently robust source of randomness,
 # as that would be probable to cause nodes powered up at the same time to emit colliding messages repeatedly.
 #
@@ -177,8 +176,8 @@
 #
 # As can be seen, the algorithm assumes that the allocatee will continue to emit requests at random intervals
 # until an allocation is granted or the allocatee is disconnected.
-#
 
+uavcan.node.ID.1.0 node_id
 # If the message transfer is anonymous (i.e., allocation request), this is the preferred ID.
 # If the message transfer is non-anonymous (i.e., allocation response), this is the allocated ID.
 #
@@ -206,16 +205,15 @@
 #       }
 #       return isOccupied(0) ? 0xFFFF : 0;
 #   }
-uavcan.node.ID.1.0 node_id
 
+uint8[16] unique_id
 # The unique-ID of the allocatee. This is the SAME value that is reported via uavcan.node.GetInfo.
 # The value is subjected to the same set of constraints; e.g., it can't be changed while the node is running,
-# and the same value must be unlikely to be used by any two different nodes anywhere in the world.
+# and the same value should be unlikely to be used by any two different nodes anywhere in the world.
 #
 # If this is a non-anonymous transfer (i.e., allocation response), allocatees will match this value against their
 # own unique-ID, and ignore the message if there is no match (except for the CSMA/CD clause, see rule C). If the IDs
 # match, then the field node_id contains the allocated node-ID value for this node.
-uint8[16] unique_id
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max / 8 == 18

--- a/uavcan/pnp/32742.NodeIDAllocationDataMTU8.0.1.uavcan
+++ b/uavcan/pnp/32742.NodeIDAllocationDataMTU8.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # The suffix "MTU8" indicates that this message is made to be compatible with transports where the maximum
 # transmission unit size is only 8 bytes, such as CAN 2.0. For other kinds of transports there is a more general,
 # more capable definition NodeIDAllocationData; it can't be used with low-MTU transports, hence the need for this
@@ -54,14 +53,13 @@
 #     2. The allocatee initializes its node-ID with the received value.
 #     3. The allocatee terminates its subscription to allocation messages.
 #     4. Exit.
-#
 
-# An arbitrary 55-bit hash of the unique-ID of the local node.
 truncated uint55 unique_id_hash
+# An arbitrary 55-bit hash of the unique-ID of the local node.
 
-# Must be empty in request messages.
-# Must be populated in response messages.
 uavcan.node.ID.1.0[<=1] allocated_node_id
+# Shall be empty in request messages.
+# Shall be populated in response messages.
 
 @assert _offset_.min == 56        # Plus the tail byte yields 8 bytes; this is for requests only
 @assert _offset_.max == 72        # Responses are non-anonymous, so they can be multi-frame

--- a/uavcan/pnp/cluster/32740.Discovery.1.0.uavcan
+++ b/uavcan/pnp/cluster/32740.Discovery.1.0.uavcan
@@ -1,26 +1,24 @@
-#
 # This message is used by redundant allocators to find each other's node-ID.
 # Please refer to the type AppendEntries for details.
 #
 # An allocator should stop publishing this message as soon as it has discovered all other allocators in the cluster.
 #
 # An exception applies: when an allocator receives a Discovery message where the list of known nodes is incomplete
-# (i.e. len(known_nodes) < configured_cluster_size), it must publish a Discovery message once. This condition
+# (i.e. len(known_nodes) < configured_cluster_size), it shall publish a Discovery message once. This condition
 # allows other allocators to quickly re-discover the cluster after a restart.
-#
 
-# This message should be broadcasted by the allocator at this interval until all other allocators are discovered.
 uint8 BROADCASTING_PERIOD = 1      # [second]
+# This message should be broadcasted by the allocator at this interval until all other allocators are discovered.
 
-# The redundant allocator cluster cannot contain more than 5 allocators.
 uint3 MAX_CLUSTER_SIZE = 5
+# The redundant allocator cluster cannot contain more than 5 allocators.
 
-# The number of allocators in the cluster as configured on the sender.
-# This value must be the same across all allocators.
 uint3 configured_cluster_size
+# The number of allocators in the cluster as configured on the sender.
+# This value shall be the same across all allocators.
 
-# Node-IDs of the allocators that are known to the publishing allocator, including the publishing allocator itself.
 void2
 uavcan.node.ID.1.0[<=5] known_nodes
+# Node-IDs of the allocators that are known to the publishing allocator, including the publishing allocator itself.
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
+++ b/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
@@ -1,4 +1,3 @@
-#
 # This type is a part of the Raft consensus algorithm. The Raft consensus is used for the maintenance of the
 # distributed allocation table between redundant allocators. The following description is focused on the exchanges
 # between redundant PnP node-ID allocators. It does not apply to the case of non-redundant allocators, because
@@ -26,20 +25,20 @@
 # Since the log is write-only and limited in growth, all allocations are permanent. This restriction is acceptable,
 # since UAVCAN is a vehicle bus, and configuration of vehicle's components is not expected to change frequently.
 # Old allocations can be removed in order to free node-IDs for new allocations by clearing the Raft log on all
-# allocators; such clearing must be performed simultaneously while the network is down, otherwise the Raft cluster
+# allocators; such clearing shall be performed simultaneously while the network is down, otherwise the Raft cluster
 # will automatically attempt to restore the lost state on the allocators where the table was cleared.
 #
 # The allocators need to be aware of each other's node-ID in order to form a cluster. In order to learn each other's
 # node-ID values, the allocators broadcast messages of type Discovery (in the same namespace) until the cluster is
 # fully discovered and all allocators know of each other's node-ID. This extension to the Raft algorithm makes the
-# cluster almost configuration-free - the only parameter that must be configured on all allocators of the cluster
+# cluster almost configuration-free - the only parameter that shall be configured on all allocators of the cluster
 # is the number of nodes in the cluster (everything else will be auto-detected).
 #
 # Runtime cluster membership changes are not supported, since they are not needed for a vehicle bus.
 #
-# As has been explained in the general description of the PnP node-ID allocation feature, allocators must watch for
+# As has been explained in the general description of the PnP node-ID allocation feature, allocators shall watch for
 # unknown static nodes appearing on the bus. In the case of a non-redundant allocator, the task is trivial, since the
-# allocation table can be updated locally. In the case of a Raft cluster, however, the network monitoring task must
+# allocation table can be updated locally. In the case of a Raft cluster, however, the network monitoring task shall
 # be performed by the leader only, since other cluster members cannot commit to the shared allocation table (i.e.,
 # the Raft log) anyway. Redundant allocators should not attempt to obtain the true unique-ID of the newly detected
 # static nodes (use zeros instead), because the allocation table is write-only: if the unique-ID of a static node
@@ -54,8 +53,9 @@
 #     completed successfully).
 #
 # All cluster maintenance traffic should normally use either the lowest or the next-to-lowest transfer priority level.
-#
 
+uint8 DEFAULT_MIN_ELECTION_TIMEOUT = 2      # [second]
+uint8 DEFAULT_MAX_ELECTION_TIMEOUT = 4      # [second]
 # Given the minimum election timeout and the cluster size,
 # the maximum recommended request interval can be derived as follows:
 #
@@ -68,15 +68,15 @@
 #
 # The timeout value is randomized in the range (MIN, MAX], according to the Raft paper. The randomization granularity
 # should be at least one millisecond or higher.
-uint8 DEFAULT_MIN_ELECTION_TIMEOUT = 2      # [second]
-uint8 DEFAULT_MAX_ELECTION_TIMEOUT = 4      # [second]
 
-# Refer to the Raft paper for explanation.
 uint32 term
 uint32 prev_log_term
 uint16 prev_log_index
 uint16 leader_commit
+# Refer to the Raft paper for explanation.
 
+void7
+Entry.1.0[<=1] entries
 # Worst case replication time per Follower can be computed as:
 #
 #   worst replication time = (node-ID capacity) * (2 trips of next_index) * (request interval per Follower)
@@ -86,13 +86,11 @@ uint16 leader_commit
 #   128 nodes * 2 trips * 0.5 seconds = 128 seconds.
 #
 # This is the amount of time it will take for a new Follower to reconstruct a full replica of the distributed log.
-void7
-Entry.1.0[<=1] entries
 
 @assert _offset_ % 8 == {0}
 
 ---
 
-# Refer to the Raft paper for explanation.
 uint32 term
 bool success
+# Refer to the Raft paper for explanation.

--- a/uavcan/pnp/cluster/391.RequestVote.1.0.uavcan
+++ b/uavcan/pnp/cluster/391.RequestVote.1.0.uavcan
@@ -1,14 +1,12 @@
-#
 # This type is a part of the Raft consensus algorithm. Please refer to the type AppendEntries for details.
-#
 
-# Refer to the Raft paper for explanation.
 uint32 term
 uint32 last_log_term
 uint16 last_log_index
+# Refer to the Raft paper for explanation.
 
 ---
 
-# Refer to the Raft paper for explanation.
 uint32 term
 bool vote_granted
+# Refer to the Raft paper for explanation.

--- a/uavcan/pnp/cluster/Entry.1.0.uavcan
+++ b/uavcan/pnp/cluster/Entry.1.0.uavcan
@@ -1,7 +1,5 @@
-#
 # One PnP node-ID allocation entry.
 # This type is a part of the Raft consensus algorithm. Please refer to the type AppendEntries for details.
-#
 
 uint32 term                     # Refer to the Raft paper for explanation.
 

--- a/uavcan/primitive/String.1.0.uavcan
+++ b/uavcan/primitive/String.1.0.uavcan
@@ -1,7 +1,5 @@
-#
 # A UTF8-encoded string of text.
 # Since the string is represented as a dynamic array of bytes, it is not null-terminated. Like Pascal string.
-#
 
 void7
 uint8[<=256] value

--- a/uavcan/primitive/Unstructured.1.0.uavcan
+++ b/uavcan/primitive/Unstructured.1.0.uavcan
@@ -1,6 +1,4 @@
-#
 # An unstructured collection of bytes, e.g., raw binary image.
-#
 
 void7
 uint8[<=256] value

--- a/uavcan/register/384.Access.1.0.uavcan
+++ b/uavcan/register/384.Access.1.0.uavcan
@@ -1,4 +1,3 @@
-#
 # This service is used to write and read a register. Write is optional, it is performed if the value provided in
 # the request is not empty.
 #
@@ -18,16 +17,16 @@
 # The timestamp provided in the response corresponds to the time when the register was read. The timestamp may
 # be empty if the server does not support timestamping or its clock is not yet synchronized with the bus.
 #
-# If only read is desired, but not write, the caller must provide a value of type Empty. That will signal the server
-# that the write operation must be skipped, and it will proceed to read the register immediately.
+# If only read is desired, but not write, the caller shall provide a value of type Empty. That will signal the server
+# that the write operation shall be skipped, and it will proceed to read the register immediately.
 #
 # If the requested register does not exist, the write operation will have no effect and the returned value will be
 # empty. Existing registers should not return Empty when read since that would make them indistinguishable from
 # nonexistent registers.
 #
-# Registers must never change their type or flags as long as the server is running. Meaning that:
+# Registers shall never change their type or flags as long as the server is running. Meaning that:
 #   - Mutability and persistence flags cannot change their states.
-#   - Read operations must always return values of the same type and same dimensionality.
+#   - Read operations shall always return values of the same type and same dimensionality.
 #     The dimensionality requirement does not apply to inherently variable-length values such as strings and
 #     unstructured chunks.
 #
@@ -78,32 +77,31 @@
 #                       |       |           | automatic node ID. Invalid values other than 65535 should be avoided for
 #                       |       |           | consistency. The factory-default value should be 65535.
 # ----------------------+-------+-----------+--------------------------------------------------------------------------
-#
-#
 
-# The name of the accessed register. Must not be empty.
-# Use the List service to obtain the list of registers on the node.
 Name.1.0 name
+# The name of the accessed register. Shall not be empty.
+# Use the List service to obtain the list of registers on the node.
 
 @assert _offset_ % 8 == {0}
 
-# Value to be written. Empty if no write is required.
 void4
 Value.1.0 value
+# Value to be written. Empty if no write is required.
 
 @assert _offset_.min % 8 == 0
 @assert _offset_.max % 8 == 0
 
 ---
 
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 # The moment of time when the register was read (not written).
 # Zero if the server does not support timestamping.
-uavcan.time.SynchronizedTimestamp.1.0 timestamp
 
+bool mutable
 # Mutable means that the register can be written using this service.
 # Immutable registers cannot be written, but that doesn't imply that their values are constant (unchanging).
-bool mutable
 
+bool persistent
 # Persistence means that the register retains its value permanently across power cycles or any other changes
 # in the state of the server, until it is explicitly overwritten (either via UAVCAN, any other interface,
 # or by the device itself).
@@ -119,17 +117,15 @@ bool mutable
 #   - Registers that trigger an activity when written are typically mutable but non-persisient.
 #   - Registers that contain factory-programmed values such as calibration coefficients that can't
 #     be changed are typically immutable but persistent.
-bool persistent
 
 void2
-
+Value.1.0 value
 # The value of the register when it was read (beware of race conditions).
 # Registers never change their type and dimensionality while the node is running.
 # Empty value means that the register does not exist (in this case the flags should be cleared/ignored).
 # By comparing the returned value against the write request the caller can determine whether the register
 # was written successfully, unless write was not requested.
 # An empty value shall never be returned for an existing register.
-Value.1.0 value
 
 @assert _offset_.min % 8 == 0
 @assert _offset_.max % 8 == 0

--- a/uavcan/register/385.List.1.0.uavcan
+++ b/uavcan/register/385.List.1.0.uavcan
@@ -1,16 +1,14 @@
-#
 # This service allows the caller to discover the names of all registers available on the server
 # by iterating the index field from zero until an empty name is returned.
 #
 # The ordering of the registers shall remain constant while the server is running.
 # The ordering is not guaranteed to remain unchanged when the server node is restarted.
-#
 
 uint16 index
 
 ---
 
-# Empty name in response means that the index is out of bounds, i.e., discovery is finished.
 Name.1.0 name
+# Empty name in response means that the index is out of bounds, i.e., discovery is finished.
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/register/Name.1.0.uavcan
+++ b/uavcan/register/Name.1.0.uavcan
@@ -1,6 +1,4 @@
-#
 # An ASCII register name.
-#
 
 void2
 uint8[<=50] name

--- a/uavcan/register/Value.1.0.uavcan
+++ b/uavcan/register/Value.1.0.uavcan
@@ -1,9 +1,7 @@
-#
 # This union contains all possible value types supported by the register protocol.
 # Numeric types can be either scalars or arrays; the former is a special case of the latter.
 #
-# In order to ensure a byte alignment of the nested arrays, the outer type must pad this union with 4 bits.
-#
+# In order to ensure a byte alignment of the nested arrays, the outer type should pad this union with 4 bits.
 
 @union                                          # The tag is 4 bits wide.
 
@@ -28,5 +26,5 @@ uavcan.primitive.array.Real16.1.0 real16        # Tag 14    Exactly representabl
 
 # Tag 15 is reserved
 
-@assert _offset_.min == 4                 # Empty and the tag
-@assert _offset_.max == 258 * 8 + 4       # 258 bytes per field max and the tag
+@assert _offset_.min == 4                       # Empty and the tag
+@assert _offset_.max == 258 * 8 + 4             # 258 bytes per field max and the tag

--- a/uavcan/time/31744.Synchronization.1.0.uavcan
+++ b/uavcan/time/31744.Synchronization.1.0.uavcan
@@ -1,4 +1,3 @@
-#
 # Network-wide time synchronization message.
 # Any node that publishes timestamped data should use this time reference.
 #
@@ -11,7 +10,7 @@
 #
 # Once a time base is chosen, it cannot be changed as long as at least one node on the network is running.
 # In other words, the time base cannot be changed while the network is operating.
-# An implication of this is that if there are redundant time synchronization masters, they all must
+# An implication of this is that if there are redundant time synchronization masters, they all shall
 # use the same time base.
 #
 # The resolution is dependent on the transport and its physical layer, but generally it can be assumed
@@ -35,7 +34,7 @@
 # the first message from a new master with a lower node ID is seen on the bus.
 #
 # In the presence of multiple masters, they all publish their time synchronization messages concurrently at all times.
-# The slaves must listen to the master with the lowest node ID and ignore the messages published by masters with
+# The slaves shall listen to the master with the lowest node ID and ignore the messages published by masters with
 # higher node ID values.
 #
 # Currently, there is a work underway to develop and validate a highly robust fault-operational time synchronization
@@ -79,7 +78,7 @@
 #               previous_tx_timestamp_per_iface[i] := 0;
 #               publishMessage(transfer_id, i, message);
 #           }
-#           transfer_id++; // Overflow must be handled correctly
+#           transfer_id++; // Overflow shall be handled correctly
 #       }
 #
 # (end of the master-side logic pseudocode)
@@ -138,7 +137,7 @@
 #               if (state == STATE_ADJUST)
 #               {
 #                   msg_invalid := message.previous_transmission_timestamp_microsecond == 0;
-#                   // Overflow must be handled correctly
+#                   // Overflow shall be handled correctly
 #                   wrong_tid := message.transfer_id != (previous_transfer_id + 1);
 #                   wrong_timing := time_since_previous_msg > MAX_PUBLICATION_PERIOD;
 #                   if (msg_invalid or wrong_tid or wrong_timing)
@@ -159,12 +158,12 @@
 #       }
 #
 # (end of the slave-side logic pseudocode)
-#
 
+uint8 MAX_PUBLICATION_PERIOD = 1                 # [second]
 # Publication period limits.
 # A master should not change its publication period while running.
-uint8 MAX_PUBLICATION_PERIOD = 1                 # [second]
 
+uint8 PUBLISHER_TIMEOUT_PERIOD_MULTIPLIER = 3
 # Synchronization slaves should normally switch to a new master if the current master was silent
 # for thrice the interval between the reception of the last two messages published by it.
 # For example, imagine that the last message was received at the time X, and the previous message
@@ -172,12 +171,11 @@ uint8 MAX_PUBLICATION_PERIOD = 1                 # [second]
 # publisher timeout is (0.5 seconds * 3) = 1.5 seconds. If there was no message from the current
 # master in this amount of time, all slaves will synchronize with another master with the next-higher
 # node ID.
-uint8 PUBLISHER_TIMEOUT_PERIOD_MULTIPLIER = 3
 
+truncated uint56 previous_transmission_timestamp_microsecond
 # The time when the PREVIOUS message was transmitted from the current publisher, in microseconds.
 # If this message is published for the first time, or if the previous transmission was more than
-# one second ago, this field must be zero.
-truncated uint56 previous_transmission_timestamp_microsecond
+# one second ago, this field shall be zero.
 
 @assert _offset_ % 8 == {0}
-@assert _offset_.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)
+@assert _offset_.max <= 56    # Shall fit into one CAN 2.0 frame (least capable transport, smallest MTU)

--- a/uavcan/time/510.GetSynchronizationMasterInfo.0.1.uavcan
+++ b/uavcan/time/510.GetSynchronizationMasterInfo.0.1.uavcan
@@ -1,31 +1,29 @@
-#
 # Every node that acts as a time synchronization master, or is capable of acting as such,
 # should support this service.
 # Its objective is to provide information about which time system is currently used in the network.
 #
 # Once a time system is chosen, it cannot be changed as long as at least one node on the network is running.
 # In other words, the time system cannot be changed while the network is operating.
-# An implication of this is that if there are redundant time synchronization masters, they all must
+# An implication of this is that if there are redundant time synchronization masters, they all shall
 # use the same time system always.
-#
 
 ---
 
+float32 error_variance      # [second^2]
 # Error variance, in second^2, of the time value reported by this master.
 # This value is allowed to change freely while the master is running.
 # For example, if the master's own clock is synchronized with a GNSS, the error variance is expected to increase
 # as signal reception deteriorates. If the signal is lost, this value is expected to grow steadily, the rate of
 # growth would be dependent on the quality of the time keeping hardware available locally (bad hardware yields
 # faster growth). Once the signal is regained, this value would drop back to nominal.
-float32 error_variance      # [second^2]
 
+TimeSystem.0.1 time_system
 # Time system currently in use by the master.
 # Cannot be changed while the network is operating.
-TimeSystem.0.1 time_system
 
+TAIInfo.0.1 tai_info
 # Actual information about TAI provided by this master, if supported.
 # The fields in this data type are optional.
-TAIInfo.0.1 tai_info
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max <= 56   # It is nice to have the response fit into one transport frame, although not required.

--- a/uavcan/time/SynchronizedTimestamp.1.0.uavcan
+++ b/uavcan/time/SynchronizedTimestamp.1.0.uavcan
@@ -1,15 +1,13 @@
-#
 # Nested data type used for representing a network-wide synchronized timestamp with microsecond resolution.
 # This data type is highly recommended for use both in standard and vendor-specific messages alike.
 #
 # If a data type is available in timestamped and non-timestamped form, its timestamped version should put
 # the timestamp at the end, in order to make the timestamped version a structural subtype of the non-timestamped
 # one, thus enhancing interoperability.
-#
 
-# Zero means that the time is not known.
-uint56 UNKNOWN = 0
+uint56 UNKNOWN = 0  # Zero means that the time is not known.
 
+truncated uint56 microsecond
 # The number of microseconds that have passed since some arbitrary moment in the past.
 # The moment of origin (i.e., the time base) is defined per-application. The current time base in use
 # can be requested from the time synchronization master, see the corresponding service definition.
@@ -20,5 +18,4 @@ uint56 UNKNOWN = 0
 #     unnecessarily wide and its overflow interval of 585 thousand years induces a mild existential crisis.
 #
 #   - Classic-CAN (not FD) transports carry up to 7 bytes of payload per frame.
-#     Time sync messages must use single-frame transfers, which means that the value can't be wider than 56 bits.
-truncated uint56 microsecond
+#     Time sync messages shall use single-frame transfers, which means that the value can't be wider than 56 bits.

--- a/uavcan/time/TAIInfo.0.1.uavcan
+++ b/uavcan/time/TAIInfo.0.1.uavcan
@@ -1,4 +1,3 @@
-#
 # This data types defines constants and runtime values pertaining to the International Atomic Time, also known as TAI.
 # See https://en.wikipedia.org/wiki/International_Atomic_Time.
 #
@@ -11,12 +10,13 @@
 #
 # UAVCAN applications should only rely on TAI whenever a global time system is needed.
 # GPS time is strongly discouraged for reasons of consistency across different positioning systems and applications.
-#
 
+uint8 DIFFERENCE_TAI_MINUS_GPS = 19    # [second]
 # The fixed difference, in seconds, between TAI and GPS time. Does not change ever.
 # Systems that use GPS time as a reference should convert that to TAI by adding this difference.
-uint8 DIFFERENCE_TAI_MINUS_GPS = 19    # [second]
 
+uint8 DIFFERENCE_TAI_MINUS_UTC_UNKNOWN = 0
+uint8 difference_tai_minus_utc
 # The current difference between TAI and UTC, if known. If unknown, set to zero.
 #
 # This value may change states between known and unknown while the master is running,
@@ -57,7 +57,5 @@ uint8 DIFFERENCE_TAI_MINUS_GPS = 19    # [second]
 #     Jul 2012 | 35
 #     Jul 2015 | 36
 #     Jan 2017 | 37
-uint8 difference_tai_minus_utc
-uint8 DIFFERENCE_TAI_MINUS_UTC_UNKNOWN = 0
 
 @assert _offset_ % 8 == {0}

--- a/uavcan/time/TimeSystem.0.1.uavcan
+++ b/uavcan/time/TimeSystem.0.1.uavcan
@@ -1,24 +1,22 @@
-#
 # Time system enumeration.
-# The time system must be the same for all masters in the network.
+# The time system shall be the same for all masters in the network.
 # It cannot be changed while the network is running.
-#
 
 void4
 truncated uint4 value
 
+uint4 MONOTONIC_SINCE_BOOT = 0
 # Monotonic time since boot.
 # Monotonic time is a time reference that doesn't change rate or make leaps.
-uint4 MONOTONIC_SINCE_BOOT = 0
 
+uint4 TAI = 1
 # International Atomic Time; https://en.wikipedia.org/wiki/International_Atomic_Time.
 # The timestamp value contains the number of microseconds elapsed since 1970-01-01T00:00:00Z TAI.
 # TAI is always a fixed integer number of seconds ahead of GPS time.
 # Systems that use GPS time as a reference should convert that to TAI by adding the fixed difference.
 # GPS time is not supported for reasons of consistency across different positioning systems and applications.
-uint4 TAI = 1
 
-# Application-specific time system of unknown properties.
 uint4 APPLICATION_SPECIFIC = 15
+# Application-specific time system of unknown properties.
 
 @assert _offset_ % 8 == {0}


### PR DESCRIPTION
Move comments past their subjects as discussed here: https://forum.uavcan.org/t/dsdl-documentation-comments/407

We failed to reach consensus but upon some pondering, I decided to implement this change because it offers greater consistency (see the linked post). The arguments against were relatively weak.

There are no logical changes in this changeset. The spec draft is being updated accordingly.