### PR TITLE
Provide explicit @extent everywhere to silence diagnostics from PyDSDL

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -399,3 +399,4 @@ DS-015
 allocatees
 Allocatee
 ABCD
+sha256

--- a/reg/drone/service/actuator/common/Status.0.1.uavcan
+++ b/reg/drone/service/actuator/common/Status.0.1.uavcan
@@ -14,3 +14,5 @@ uint32 error_count
 FaultFlags.0.1 fault_flags
 
 # TODO: add vibration
+
+@extent 63 * 8  # Single-frame transfer over CAN FD.

--- a/reg/drone/service/actuator/common/sp/_.0.1.uavcan
+++ b/reg/drone/service/actuator/common/sp/_.0.1.uavcan
@@ -19,3 +19,5 @@
 float16 EPSILON = 2 ** -11
 # The float epsilon defined for convenience.
 # See https://en.wikipedia.org/wiki/Machine_epsilon.
+
+@extent 0  # This type is not intended for runtime use.

--- a/uavcan/file/405.GetInfo.0.1.uavcan
+++ b/uavcan/file/405.GetInfo.0.1.uavcan
@@ -2,6 +2,8 @@
 
 Path.1.0 path
 
+@extent 300 * 8
+
 ---
 
 Error.1.0 error
@@ -19,3 +21,5 @@ bool is_readable            # The item can be read by the caller (applies to fil
 bool is_writeable           # The item can be written by the caller (applies to files and directories).
 # If such entry does not exist, all flags should be cleared/ignored.
 void4
+
+@extent 48 * 8

--- a/uavcan/file/406.List.0.1.uavcan
+++ b/uavcan/file/406.List.0.1.uavcan
@@ -20,6 +20,8 @@ void32                  # Reserved for future use.
 
 Path.1.0 directory_path
 
+@extent 300 * 8
+
 ---
 
 void32                  # Reserved for future use.
@@ -32,3 +34,5 @@ Path.1.0 entry_base_name
 # For example, suppose there is a file "/foo/bar/baz.bin". Listing the directory with the path "/foo/bar/" (the slash
 # at the end is optional) at the index 0 will return "baz.bin". Listing the same directory at the index 1 (or any
 # higher) will return an empty name "", indicating that the caller has reached the end of the list.
+
+@extent 300 * 8

--- a/uavcan/file/407.Modify.1.0.uavcan
+++ b/uavcan/file/407.Modify.1.0.uavcan
@@ -39,6 +39,10 @@ void30
 Path.1.0 source
 Path.1.0 destination
 
+@extent 600 * 8
+
 ---
 
 Error.1.0 error
+
+@extent 48 * 8

--- a/uavcan/file/408.Read.1.0.uavcan
+++ b/uavcan/file/408.Read.1.0.uavcan
@@ -31,8 +31,12 @@ truncated uint40 offset
 
 Path.1.0 path
 
+@extent 300 * 8
+
 ---
 
 Error.1.0 error
 
 uint8[<=256] data
+
+@extent 300 * 8

--- a/uavcan/file/409.Write.1.0.uavcan
+++ b/uavcan/file/409.Write.1.0.uavcan
@@ -15,6 +15,10 @@ Path.1.0 path
 
 uint8[<=192] data   # 192 = 128 + 64; the write protocol permits usage of smaller chunks.
 
+@extent 600 * 8
+
 ---
 
 Error.1.0 error
+
+@extent 48 * 8

--- a/uavcan/node/430.GetInfo.1.0.uavcan
+++ b/uavcan/node/430.GetInfo.1.0.uavcan
@@ -2,6 +2,8 @@
 # All of the returned information shall be static (unchanged) while the node is running.
 # It is highly recommended to support this service on all nodes.
 
+@sealed
+
 ---
 
 Version.1.0 protocol_version
@@ -61,3 +63,4 @@ uint8[<=222] certificate_of_authenticity
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max == (313 * 8)     # At most five CAN FD frames
+@extent 448 * 8

--- a/uavcan/node/434.GetTransportStatistics.0.1.uavcan
+++ b/uavcan/node/434.GetTransportStatistics.0.1.uavcan
@@ -1,6 +1,8 @@
 # Returns a set of general low-level transport statistical counters.
 # Servers are encouraged but not required to sample the data atomically.
 
+@sealed
+
 ---
 
 uint8 MAX_NETWORK_INTERFACES = 3
@@ -18,3 +20,4 @@ IOStatistics.0.1[<=MAX_NETWORK_INTERFACES] network_interface_statistics
 # The methods of counting are implementation-defined.
 
 @assert _offset_.max <= (63 * 8)      # One CAN FD frame
+@extent 192 * 8

--- a/uavcan/node/435.ExecuteCommand.1.0.uavcan
+++ b/uavcan/node/435.ExecuteCommand.1.0.uavcan
@@ -69,6 +69,7 @@ uint8[<=uavcan.file.Path.1.0.MAX_LENGTH] parameter
 
 @assert _offset_ % 8 == {0}
 @assert _offset_.max <= (124 * 8)     # Two CAN FD frames max
+@extent 300 * 8
 
 ---
 
@@ -81,3 +82,5 @@ uint8 STATUS_BAD_STATE      = 5     # The current state of the node does not per
 uint8 STATUS_INTERNAL_ERROR = 6     # The operation should have succeeded but an unexpected failure occurred
 uint8 status
 # The result of the request.
+
+@extent 48 * 8

--- a/uavcan/node/port/431.List.0.1.uavcan
+++ b/uavcan/node/port/431.List.0.1.uavcan
@@ -34,7 +34,10 @@
 ID.1.0 port_id_lower_boundary
 
 @assert _offset_ == {24}
+@sealed
 
 ---
 
 uint16[<=128] port_ids  # See above for the full description of the logic.
+
+@extent 300 * 8

--- a/uavcan/node/port/432.GetInfo.0.1.uavcan
+++ b/uavcan/node/port/432.GetInfo.0.1.uavcan
@@ -12,6 +12,7 @@
 ID.1.0 port_id  # The port of interest; can be either a service or a subject.
 
 @assert _offset_ == {24}
+@sealed
 
 ---
 
@@ -39,3 +40,5 @@ uint8[<=50] data_type_full_name
 uavcan.node.Version.1.0 data_type_version
 # The version numbers of the data type used at this port.
 # Zeros if the port does not exist.
+
+@extent 192 * 8

--- a/uavcan/node/port/433.GetStatistics.0.1.uavcan
+++ b/uavcan/node/port/433.GetStatistics.0.1.uavcan
@@ -4,6 +4,7 @@
 ID.1.0 port_id  # The port of interest; can be either a service or a message.
 
 @assert _offset_ == {24}
+@sealed
 
 ---
 
@@ -26,3 +27,4 @@ uavcan.node.IOStatistics.0.1 statistics
 # The exact definition of an error and the methods of their counting are implementation-defined.
 
 @assert _offset_ == {15 * 8}      # 15 bytes max; this service is optimized for high-frequency polling
+@extent 48 * 8

--- a/uavcan/pnp/8165.NodeIDAllocationData.2.0.uavcan
+++ b/uavcan/pnp/8165.NodeIDAllocationData.2.0.uavcan
@@ -190,3 +190,4 @@ uint8[16] unique_id
 # the allocated node-ID value for this node.
 
 @assert _offset_.max / 8 == 18
+@extent 48 * 8

--- a/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
+++ b/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
@@ -87,9 +87,12 @@ Entry.1.0[<=1] entries
 # This is the amount of time it will take for a new Follower to reconstruct a full replica of the distributed log.
 
 @assert _offset_ % 8 == {0}
+@extent 96 * 8
 
 ---
 
 uint32 term
 bool success
 # Refer to the Raft paper for explanation.
+
+@extent 48 * 8

--- a/uavcan/pnp/cluster/391.RequestVote.1.0.uavcan
+++ b/uavcan/pnp/cluster/391.RequestVote.1.0.uavcan
@@ -5,8 +5,12 @@ uint32 last_log_term
 uint16 last_log_index
 # Refer to the Raft paper for explanation.
 
+@extent 48 * 8
+
 ---
 
 uint32 term
 bool vote_granted
 # Refer to the Raft paper for explanation.
+
+@extent 48 * 8

--- a/uavcan/pnp/cluster/8164.Discovery.1.0.uavcan
+++ b/uavcan/pnp/cluster/8164.Discovery.1.0.uavcan
@@ -23,3 +23,4 @@ uavcan.node.ID.1.0[<=5] known_nodes
 # Node-IDs of the allocators that are known to the publishing allocator, including the publishing allocator itself.
 
 @assert _offset_ % 8 == {0}
+@extent 96 * 8

--- a/uavcan/register/384.Access.1.0.uavcan
+++ b/uavcan/register/384.Access.1.0.uavcan
@@ -89,6 +89,7 @@ Value.1.0 value
 
 @assert _offset_.min % 8 == 0
 @assert _offset_.max % 8 == 0
+@sealed
 
 ---
 
@@ -126,3 +127,5 @@ Value.1.0 value
 # By comparing the returned value against the write request the caller can determine whether the register
 # was written successfully, unless write was not requested.
 # An empty value shall never be returned for an existing register.
+
+@sealed

--- a/uavcan/register/385.List.1.0.uavcan
+++ b/uavcan/register/385.List.1.0.uavcan
@@ -6,7 +6,11 @@
 
 uint16 index
 
+@sealed
+
 ---
 
 Name.1.0 name
 # Empty name in response means that the index is out of bounds, i.e., discovery is finished.
+
+@sealed

--- a/uavcan/time/510.GetSynchronizationMasterInfo.0.1.uavcan
+++ b/uavcan/time/510.GetSynchronizationMasterInfo.0.1.uavcan
@@ -7,6 +7,8 @@
 # An implication of this is that if there are redundant time synchronization masters, they all shall
 # use the same time system always.
 
+@extent 48 * 8
+
 ---
 
 float32 error_variance      # [second^2]
@@ -24,3 +26,5 @@ TimeSystem.0.1 time_system
 TAIInfo.0.1 tai_info
 # Actual information about TAI provided by this master, if supported.
 # The fields in this data type are optional.
+
+@extent 192 * 8


### PR DESCRIPTION
About the diagnostic: https://forum.uavcan.org/t/data-type-extensibility-and-composition/827/20?u=pavel.kirienko
...which was implemented in: https://github.com/UAVCAN/pydsdl/pull/45/commits/e2816c746fb3c00f4089cb97da00ff416626433d

Example:

```
public_regulated_data_types/uavcan/file/405.GetInfo.0.1.uavcan:1: Request: Extent is not specified explicitly, defaulting to 170 bytes. To accept the default extent and silence this diagnostic, add the following line near the end of the definition: `@extent 170 * 8`
```

Some of the values are rounded to ((integer power of two) - 32) to optimize dynamic memory allocations for half-fit or buddy allocators which are expected to be commonly used in relevant applications. Other than that, the extent values are more or less the best guess.