### PR TITLE
[DS-015] Minor non-semantic adjustments

### DIFF
--- a/reg/drone/README.md
+++ b/reg/drone/README.md
@@ -93,15 +93,15 @@ UAVCAN implementation libraries are optimized for handling multi-frame transfers
 
 ## Conventions
 
-All physical quantities except error variance should be represented as `float32` by default.
-Error variance and covariance matrices should use `float16` by default.
+- All physical quantities except error variance should be represented as `float32` by default.
+  Error variance and covariance matrices should use `float16` by default.
 
-Covariance matrices should be represented as their upper-right triangles using the matrix packing rules
-defined in the Specification.
+- Covariance matrices should be represented as their upper-right triangles using the matrix packing rules
+  defined in the Specification.
 
-Types with (co)variance should be suffixed `Var`; types with timestamp should be suffixed `Ts`;
-types with both should be suffixed `VarTs`.
-The timestamp field, if present, should be the first one;
-error (co)variance information should follow the data field(s) it relates to.
+- Types with (co)variance should be suffixed `Var`; types with timestamp should be suffixed `Ts`;
+  types with both should be suffixed `VarTs`.
+  The timestamp field, if present, should be the first one;
+  error (co)variance information should follow the data field(s) it relates to.
 
-Publishers of measurements or estimates should apply low-pass filtering to avoid frequency aliasing.
+- Publishers of measurements or estimates should apply low-pass filtering to avoid frequency aliasing.

--- a/reg/drone/README.md
+++ b/reg/drone/README.md
@@ -103,3 +103,5 @@ Types with (co)variance should be suffixed `Var`; types with timestamp should be
 types with both should be suffixed `VarTs`.
 The timestamp field, if present, should be the first one;
 error (co)variance information should follow the data field(s) it relates to.
+
+Publishers of measurements or estimates should apply low-pass filtering to avoid frequency aliasing.

--- a/reg/drone/phy/acoustics/Note.0.1.uavcan
+++ b/reg/drone/phy/acoustics/Note.0.1.uavcan
@@ -1,19 +1,9 @@
 # Description of a generic musical note in terms of basic physical quantities.
-# This type may be used to control sound notification emitters.
+#
+# This type may be used to control sound notification emitters assuming the best effort policy:
+# if the requested parameters exceed the capabilities of the emitter, the closest possible values should be assumed.
 
 uavcan.si.unit.frequency.Scalar.1.0 frequency
-# If the requested frequency is outside of the supported range, the command should be ignored.
-# A non-positive or non-finite value here renders the command invalid.
-
 uavcan.si.unit.duration.Scalar.1.0 duration
-# If the requested duration is longer than the supported maximum, the maximum valid duration should be assumed.
-# If a new command is received while another one is being played, the new command takes precedence and the old one
-# is canceled.
-# A non-positive or non-finite value here renders the command invalid.
-
 uavcan.si.unit.power.Scalar.1.0 acoustic_power
-# Desired acoustic power output.
-# The emitter should apply best effort to comply, but there are no accuracy requirements.
-# Emitters that are unable to adjust the acoustic power would ignore this parameter.
-
 @sealed

--- a/reg/drone/phy/electricity/Source.0.1.uavcan
+++ b/reg/drone/phy/electricity/Source.0.1.uavcan
@@ -3,8 +3,8 @@
 
 Power.0.1 power
 # Total instant load power.
-# Positive current flows into the source (regeneration/consumption).
-# Negative current flows from the source to the load (discharge/production).
+# Positive current flows into the source (power sinking).
+# Negative current flows from the source to the power supply network (power sourcing).
 
 uavcan.si.unit.energy.Scalar.1.0 energy
 # A pessimistic estimate of the amount of energy that can be reclaimed from the source in its current state.

--- a/reg/drone/srv/actuator/common/Feedback.0.1.uavcan
+++ b/reg/drone/srv/actuator/common/Feedback.0.1.uavcan
@@ -5,11 +5,11 @@
 # The priority of this message should be the same as that of the corresponding setpoint message.
 
 reg.drone.srv.common.Heartbeat.0.1 heartbeat
-# If armed, the actuator provides service according to its nominal performance characteristics.
+# If ENGAGED, the actuator provides service according to its nominal performance characteristics.
 # Otherwise, no availability guarantees are provided.
 # Notice that the feedback type is a structural subtype of the heartbeat type, so one can subscribe to a
 # feedback subject using the heartbeat type. Similarly, the heartbeat type is a structural subtype of the
-# Arming state type, meaning that one can use the Arming type as well.
+# Readiness type, meaning that one can use the Readiness type as well.
 
 int8 demand_factor_pct  # [percent]
 # Percentage of the maximum rated output intensity. May exceed +-100% in case of overload.

--- a/reg/drone/srv/actuator/common/Status.0.1.uavcan
+++ b/reg/drone/srv/actuator/common/Status.0.1.uavcan
@@ -8,7 +8,7 @@ uavcan.si.unit.temperature.Scalar.1.0 controller_temperature
 # Sampled temperatures. If multiple values are available, reduction is implementation-defined.
 
 uint32 error_count
-# Incremented once per occurrence. Reset to zero when armed.
+# Incremented once per occurrence. Reset to zero when ENGAGED.
 # The exact definition of what constitutes an error is implementation-dependent.
 
 FaultFlags.0.1 fault_flags

--- a/reg/drone/srv/actuator/common/_.0.1.uavcan
+++ b/reg/drone/srv/actuator/common/_.0.1.uavcan
@@ -4,7 +4,7 @@
 
 float32 CONTROL_TIMEOUT = 1.0  # [seconds]
 # The actuator is allowed to enter a safe state (e.g., stop the controlled mechanism, disconnect itself from
-# the load, etc. depending on the specifics of the application at hand) if no setpoint or arming messages
+# the load, etc. depending on the specifics of the application at hand) if no setpoint or readiness control messages
 # have been received in this amount of time. Implementations are allowed to reduce this value, but never increase it.
 
 uint8 MAX_PUBLICATION_PERIOD = 1  # [second]

--- a/reg/drone/srv/actuator/esc/_.0.1.uavcan
+++ b/reg/drone/srv/actuator/esc/_.0.1.uavcan
@@ -10,10 +10,9 @@
 #     Every message is consumed by all participants according to their index in the group.
 #     The setpoint subject defines the group. There may be an arbitrary number of such groups in the network.
 #
-#   - Arming subject. Every participant subscribes to the same arming subject which is used to command the
-#     state of the group: sleep, disarmed, or armed. In many cases there will be one global arming subject
-#     controlling the state of the entire system; in other cases there will be dedicated arming controls on a
-#     per-subsystem basis.
+#   - Readiness subject. Every participant subscribes to the same readiness control subject which is used to command
+#     the state of the group: sleep, standby, or engaged. In many cases there will be one global subject controlling
+#     the state of the entire system; in other cases there will be dedicated controls on a per-subsystem basis.
 #
 #   - Individual subjects, whose subject-ID is offset from the setpoint subject-ID `S` as a function of
 #     group member index `i` as specified below.
@@ -21,7 +20,7 @@
 #                                                   SUBJECT     TYPE                                        SUBJECT-ID
 #  +----------------+
 #  |   Controller   |---------+------------+----... setpoint    reg.drone.srv.actuator.common.sp.*          S
-#  |                |-------+-)----------+-)----... arming      reg.drone.srv.common.Arming                 S+1
+#  |                |-------+-)----------+-)----... readiness   reg.drone.srv.common.Readiness              S+1
 #  +----------------+       | |          | |
 #   ^ ^ ^ ^  ^ ^ ^ ^        v v          v v
 #   | | | |  | | | |   +---------+  +---------+
@@ -49,9 +48,9 @@
 #
 #   SETPOINT SUBJECT
 #
-# The setpoint subject is ignored unless the drive is ARMED. As long as the drive is not ARMED, it shall not apply
+# The setpoint subject is ignored unless the drive is ENGAGED. As long as the drive is not ENGAGED, it shall not apply
 # any power to the load excepting non-operational scenarios such as maintenance and diagnostics, which are
-# outside of the scope of this service definition. More on arming and safety in the next section.
+# outside of the scope of this service definition. More on readiness and safety in the next section.
 #
 # Upon reception of a setpoint message, a group participant fetches its setpoint from the array using the array
 # element whose index equals the index of the group participant. By virtue of the Implicit Zero Extension Rule,
@@ -64,7 +63,7 @@
 # While stopped, the drive may either allow the load to freewheel or it may force it to a particular parking position,
 # depending on the implementation requirements. The actual state of the load may be continuously reported using the
 # dynamics subject. Notice that per the safety rule introduced earlier, the parking position may be impossile
-# to enforce unless the drive is ARMED because it may require delivering power to the load.
+# to enforce unless the drive is ENGAGED because it may require delivering power to the load.
 #
 # The setpoint message types that can be used to command a group of drives are defined in
 # reg.drone.srv.actuator.common.sp; please read the documentation related to that namespace for further information.
@@ -94,33 +93,33 @@
 #  -  A non-finite setpoint is to be treated as zero.
 #
 #
-#   ARMING SUBJECT
+#   READINESS SUBJECT
 #
-# The default state is DISARMED. While disarmed, the drive is not allowed to deliver power to the load,
-# and the setpoint subject is ignored. The drive shall enter the disarmed state automatically if the arming subject
+# The default state is STANDBY. While in this state, the drive is not allowed to deliver power to the load,
+# and the setpoint subject is ignored. The drive shall enter this state automatically if the readiness subject
 # is not updated for CONTROL_TIMEOUT.
 #
-# While the drive is ARMED, the setpoint commands are processed normally as described in the adjacent section.
+# While the drive is ENGAGED, the setpoint commands are processed normally as described in the adjacent section.
 # If the drive does not support bidirectional operation, implementations are recommended to ensure that the load
-# is driven at some minimum power level (idling) while the drive is armed regardless of the commanded setpoint,
+# is driven at some minimum power level (idling) while the drive is ENGAGED regardless of the commanded setpoint,
 # unless such behavior is deemed incompatible with the functional requirements of the controlled drive.
 #
-# If the selected arming state is SLEEP, the behavior is implementation-defined. Implementations are recommended to
+# If the selected readiness state is SLEEP, the behavior is implementation-defined. Implementations are recommended to
 # power off the high-voltage circuitry and all non-essential components (e.g., LED indication, sensors, etc.)
 # to minimize the power consumption.
 #
-# Implementations are recommended to announce transitions between the arming states using audiovisual feedback.
+# Implementations are recommended to announce transitions between the readiness states using audiovisual feedback.
 #
 # The worst-case state transition latency is not defined. The controlling element (that is, the unit that publishes
-# to the setpoint and arming subjects) is expected to monitor the actual arming status of each component using
+# to the setpoint and readiness subjects) is expected to monitor the actual readiness status of each component using
 # the feedback subject. For example, a sensorless electric motor drive may choose to spool-up before entering the
-# ARMED state, which would obviously take time; as soon as the spool-up is finished, the drive would switch its
-# reported status from DISARMED to ARMED, thereby indicating that it is ready for normal operation.
+# ENGAGED state, which would obviously take time; as soon as the spool-up is finished, the drive would switch its
+# reported status from STANDBY to ENGAGED, thereby indicating that it is ready for normal operation.
 #
 #
 #   PUBLISHED SUBJECTS
 #
-# The following subjects shall be published immediately after a new setpoint is applied even if the drive is DISARMED:
+# The following subjects shall be published immediately after a new setpoint is applied even if the drive is STANDBY:
 #
 #   SUBJECT             RECOMMENDED PRIORITY
 #   ---------------------------------------------
@@ -129,7 +128,7 @@
 #   dynamics            second to the setpoint
 #
 # If no setpoint is being published, these subjects should continue being updated at least at 1/MAX_PUBLICATION_PERIOD.
-# The publication rate requirements do not apply if the arming state is SLEEP.
+# The publication rate requirements do not apply if the readiness state is SLEEP.
 #
 # If the setpoint publication rate exceeds 50 Hz, implementations are allowed (but not required) to throttle these
 # subjects by dropping some of the messages such that the publication rate of each subject does not exceed 50 Hz.

--- a/reg/drone/srv/actuator/servo/_.0.1.uavcan
+++ b/reg/drone/srv/actuator/servo/_.0.1.uavcan
@@ -6,8 +6,8 @@
 #   - reg.drone.phy.dynamics.trans.Linear[Ts]
 # For generality, either or both of these types are referred to as "timestamped dynamics" or "non-timestamped dynamics".
 #
-# The default arming state is DISARMED. While disarmed, the servo is not allowed to apply force to the load,
-# and the setpoint subject is ignored. The servo shall enter the disarmed state automatically if the arming subject
+# The default readiness state is STANDBY. While in this state, the servo is not allowed to apply force to the load,
+# and the setpoint subject is ignored. The servo shall enter the STANDBY state automatically if the readiness subject
 # is not updated for CONTROL_TIMEOUT.
 #
 # The subjects defined by this service are shown on the following canvas. Implementers are encouraged to add
@@ -17,7 +17,7 @@
 #
 #   +------------+   setpoint       +------------+      (non-timestamped dynamics) (see below)          R
 #   |            |----------------->|            |
-#   |            |   arming         |            |      reg.drone.srv.common.Arming                     any
+#   |            |   readiness      |            |      reg.drone.srv.common.Readiness                  any
 #   |            |----------------->|            |
 #   |            |   feedback       |            |      reg.drone.srv.actuator.common.Feedback          R
 #   |            |<-----------------|            |
@@ -32,7 +32,7 @@
 # Should it be necessary to control a group of servos in lockstep, an arbitrary number of them may subscribe
 # to the same setpoint subject (their published subjects would be different of course).
 #
-# If the servo is ARMED, setpoint messages are processed as follows: the first field of the kinematic setpoint type
+# If the servo is ENGAGED, setpoint messages are processed as follows: the first field of the kinematic setpoint type
 # that contains a finite value is taken as the commanded setpoint. The following non-negative finite fields define
 # the motion profile, where negative and non-finite values are ignored.
 #
@@ -67,7 +67,7 @@
 #                                                   SUBJECT     TYPE
 #  +----------------+
 #  |   Controller   |---------+------------+----... setpoint    reg.drone.srv.actuator.common.sp.*
-#  |                |-------+-)----------+-)----... arming      reg.drone.srv.common.Arming
+#  |                |-------+-)----------+-)----... readiness   reg.drone.srv.common.Readiness
 #  +----------------+       | |          | |
 #   ^ ^ ^ ^  ^ ^ ^ ^        v v          v v
 #   | | | |  | | | |   +---------+  +---------+
@@ -84,13 +84,13 @@
 #   | +-----------------------------------+ |
 #   +---------------------------------------+
 #
-# If the selected arming state is SLEEP, the behavior is implementation-defined. Implementations are recommended to
+# If the selected readiness state is SLEEP, the behavior is implementation-defined. Implementations are recommended to
 # power off the high-voltage circuitry and all non-essential components (e.g., LED indication, sensors, etc.)
-# to minimize the power consumption. The publication rate requirements do not apply if the arming state is SLEEP.
+# to minimize the power consumption. The publication rate requirements do not apply if the state is SLEEP.
 #
-# The worst-case arming state transition latency is not defined.
+# The worst-case readiness state transition latency is not defined.
 #
-# The following subjects shall be published immediately after a new setpoint is applied even if the servo is DISARMED:
+# The following subjects shall be published immediately after a new setpoint is applied even if the servo is STANDBY:
 #
 #   SUBJECT             RECOMMENDED PRIORITY
 #   ---------------------------------------------

--- a/reg/drone/srv/air_data_computer/_.0.1.uavcan
+++ b/reg/drone/srv/air_data_computer/_.0.1.uavcan
@@ -2,21 +2,21 @@
 #
 # An air data computer service is generally a non-interactive publish-only service: when activated,
 # it keeps publishing its measurements at a fixed rate over several subjects until deactivated.
-# The activation/deactivation, if supported, is managed via the standard arming command service.
+# The activation/deactivation, if supported, is managed via the standard readiness control service.
 # The data update rates and other parameters are controlled via the Register API using implementation-defined
 # register names.
 #
-# An air data computer whose arming state is SLEEP is allowed to cease all network activity.
+# An air data computer whose readiness state is SLEEP is allowed to cease all network activity.
 #
-# An air data computer whose arming state is DISARMED is recommended to behave as if its state was ARMED;
+# An air data computer whose readiness state is STANDBY is recommended to behave as if its state was ENGAGED;
 # implementations are recommended to leverage this state to perform any necessary maintenance activities
-# such as calibration, self-heating, etc. The service should not report its own status as ARMED until said
+# such as calibration, self-heating, etc. The service should not report its own status as ENGAGED until said
 # maintenance activities have been completed. Therefore, the high-level controler (e.g., the flight
 # management unit) may delay the take-off until the service is ready.
 #
-# An air data computer whose arming state is ARMED is required to comply with the requirements set out below.
+# An air data computer whose readiness state is ENGAGED is required to comply with the requirements set out below.
 #
-# An armed service should publish the following data subjects synchronously at the same configurable rate
+# An ENGAGED service should publish the following data subjects synchronously at the same configurable rate
 # which should not be lower than the specified limit. The measurements should be low-pass filtered
 # to avoid frequency aliasing effects.
 #
@@ -31,19 +31,19 @@
 # ready for consumption by clients. If desired, indicated airspeed may be reported over an implementation-defined
 # subject.
 #
-# In addition to the above, an armed service should publish the following service subjects at an implementation-defined
-# rate:
+# In addition to the above, an ENGAGED service should publish the following service subjects at an
+# implementation-defined rate:
 #
 #   PUBLISHED SUBJECT       TYPE
 #   heartbeat               reg.drone.srv.common.Heartbeat
 #   sensor status           reg.drone.srv.sensor.Status
 #
-# Despite being a non-interactive service, it is recommended to subscribe to the arming command subject.
-# This recommendation may be omitted if the service does not support arming state selection, in which case it should
-# always report itself as being ARMED.
+# Despite being a non-interactive service, it is recommended to subscribe to the readiness command subject.
+# This recommendation may be omitted if the service does not support readiness state selection, in which case it should
+# always report itself as being ENGAGED.
 #
 #   SUBSCRIBED SUBJECT      TYPE
-#   arming command          reg.drone.srv.common.Arming
+#   readiness control       reg.drone.srv.common.Readiness
 
 float32 MAX_PUBLICATION_PERIOD = 0.1  # [second]
 

--- a/reg/drone/srv/battery/Status.0.1.uavcan
+++ b/reg/drone/srv/battery/Status.0.1.uavcan
@@ -7,12 +7,12 @@ reg.drone.srv.common.Heartbeat.0.1 heartbeat
 # after another, the depletion of energy in the first battery is not a fault condition and it should not be reported
 # as such. This follows from the good service design principles reviewed in https://uavcan.org/guide.
 #
-# The arming state depicts the ability of the battery (or its power electronics) to deliver full rated power
+# The readiness state depicts the ability of the battery (or its power electronics) to deliver full rated power
 # and whether the overdischarge protections are active.
-# When the battery is not armed, it may limit the output power below the nominal rated value and disconnect the load
+# When the battery is not ENGAGED, it may limit the output power below the nominal rated value and disconnect the load
 # should the charge level fall below the critical level.
-# When the battery is armed, it is not permitted to limit the output power or energy regardless of the risk of damage.
-# If the adaptive protection is not supported, the battery should always report its status as ARMED.
+# When the battery is ENGAGED, it is not permitted to limit the output power or energy regardless of the risk of damage.
+# If the adaptive protection is not supported, the battery should always report its status as ENGAGED.
 
 uavcan.si.unit.temperature.Scalar.1.0[2] temperature_min_max
 # The minimum and maximum readings of the pack temperature sensors.

--- a/reg/drone/srv/battery/_.0.1.uavcan
+++ b/reg/drone/srv/battery/_.0.1.uavcan
@@ -8,22 +8,22 @@
 # Observe that only the first subject can be used for estimating the endurance of the power source. The other subjects
 # are designed for monitoring, diagnostics, and maintenance.
 #
-# Optionally, the battery service can subscribe to an arming command subject (see drone.common.Arming), which enables
-# the following two optional capabilities:
+# Optionally, the battery service can subscribe to a readiness control subject (see reg.drone.srv.common.Readiness),
+# which enables the following two optional capabilities:
 #
-#   - SLEEP mode: when the arming subject commands the sleep state, the battery management system may enter a
+#   - SLEEP mode: when the readiness subject commands the sleep state, the battery management system may enter a
 #     low power consumption state, possibly deactivating some of its capabilities.
 #
-#   - DISARMED mode: the battery management system may implement additional safety protections that may otherwise
+#   - STANDBY mode: the battery management system may implement additional safety protections that may otherwise
 #     interfere with the normal operation of the vehicle. For example, the traction battery may limit the maximum
-#     load current and the depth of discharge unless the commanded state is ARMED. By doing so, the battery can
+#     load current and the depth of discharge unless the commanded state is ENGAGED. By doing so, the battery can
 #     protect itself and the supplied high-voltage DC network from accidental damage while the vehicle is parked.
 #     Limiting the output power or discharge of the traction battery might lead to catastrophic consequences in
-#     an aerial vehicle, hence such safety checks are to be disabled once the battery is commanded into the ARMED
+#     an aerial vehicle, hence such safety checks are to be disabled once the battery is commanded into the ENGAGED
 #     state.
 #
-# If the advanced arming capabilities are not supported, the battery may not subscribe to the arming subject,
-# in which case it should permanently report its state as ARMED unless the battery is unfit for use (e.g., due
+# If readiness state selection is not supported, the battery may not subscribe to the readiness control subject,
+# in which case it should permanently report its state as ENGAGED unless the battery is unfit for use (e.g., due
 # to degradation of a failure).
 #
 # By convention, positive power (current) flows from the DC network into the battery. Therefore, the current is

--- a/reg/drone/srv/common/Heartbeat.0.1.uavcan
+++ b/reg/drone/srv/common/Heartbeat.0.1.uavcan
@@ -4,12 +4,12 @@
 # The service heartbeat should be published either on a separate subject, or as a structural supertype of a
 # service-specific status subject. The publication rate is service-specific but it should not be lower than 1 Hz.
 #
-# This is a structural subtype of the Arming type.
+# This is a structural subtype of the Readiness type.
 
 uint8 MAX_PUBLICATION_PERIOD = 1
 # Any service that is not in the SLEEP state should publish its heartbeat (or a derived status) at least at this rate.
 
-Arming.0.1 arming
+Readiness.0.1 readiness
 uavcan.node.Health.1.0 health
 
 @sealed

--- a/reg/drone/srv/common/Readiness.0.1.uavcan
+++ b/reg/drone/srv/common/Readiness.0.1.uavcan
@@ -1,13 +1,13 @@
-# The arming state is used to command or report the availability (readiness) status of a networked service (subsystem).
+# The readiness state is used to command or report the availability status of a networked service (subsystem).
 #
-# A simple system would usually have one arming command subject published by some central controller
+# A simple system would usually have one readiness command subject published by some central controller
 # that other components subscribe to. Said subject acts as a global power switch. Every subsystem controlled in
-# such way would usually report its arming status back to account for the fact that the transition between the arming
-# states may not be instantaneous. The arming status reporting is done by means of the service heartbeat type
-# that is also defined in this namespace; the service heartbeat type is a structural subtype of this arming type.
+# such way would usually report its readiness status back to account for the fact that the transition between different
+# readiness states may not be instantaneous. The readiness status reporting is done by means of the service heartbeat
+# type that is also defined in this namespace; the service heartbeat type is a structural subtype of this type.
 #
 #   +------------+
-#   | Controller |----------+----------------+----------------+---------...     arming command subject
+#   | Controller |----------+----------------+----------------+---------...     readiness command subject
 #   +------------+          |                |                |
 #     ^   ^   ^             v                v                v
 #     |   |   |        +---------+      +---------+      +---------+
@@ -18,7 +18,7 @@
 #     |   +----------------------------------+                |                 service heartbeat subjects
 #     +-------------------------------------------------------+
 #
-# In a less trivial use case there may be an arbitrary number of such arming command subjects (local power switches)
+# In a less trivial use case there may be an arbitrary number of such readiness command subjects (local power switches)
 # controlling various systems within the vehicle (e.g., propulsion, perception sensors, communication, etc).
 #
 # The publication rate is defined on a per-service basis, but it should never be lower than 1 Hz,
@@ -29,27 +29,29 @@ truncated uint2 value
 uint2 SLEEP = 0
 # The long-term state of minimal power consumption.
 # Typically, most subsystems are switched into the SLEEP mode when the vehicle is parked and powered off.
-# Subsystems that do not support the SLEEP state should treat it as an equivalent of DISARMED.
+# Subsystems that do not support the SLEEP state should treat it as an equivalent of STANDBY.
 #
 # A subsystem may require a substantial amount of time to exit the sleep mode (for example, time may be needed to
 # boot the operating system and run the self test procedures).
 #
 # While in the SLEEP mode, the subsystem is allowed to cease service provision and stop all network activity
-# regardless of other requirements, except that it shall be able to reactivate itself if an Arming message is
+# regardless of other requirements, except that it shall be able to reactivate itself if a Readiness message is
 # received commanding any state other than SLEEP.
 
 # Value 1 is invalid and shall never be commanded.
-# Implementations receiving this value should interpret it either as SLEEP or DISARMED.
+# Implementations receiving this value should interpret it either as SLEEP or STANDBY.
 
-uint2 DISARMED = 2
+uint2 STANDBY = 2
 # The state of being ready to enter the normal operating mode in a short order.
-# A subsystem that is DISARMED should be able to participate in the normal network activity.
+# A subsystem that is in STANDBY state should be able to participate in the normal network activity.
 # This is the default state that the subsystem should reside in after power-on until explicitly commanded otherwise.
 
-uint2 ARMED = 3
-# When ARMED, the subsystem is performing its main intended function at the nominal performance characteristics.
-# A subsystem may require a short amount of time, possibly under a few seconds, to switch between the ARMED and
-# DISARMED states.
-# Some subsystems may not differentiate between DISARMED and ARMED (e.g., offboard communication hardware).
+uint2 ENGAGED = 3
+# When ENGAGED, the subsystem is performing its main intended function at the nominal performance characteristics.
+# A subsystem may require a short amount of time, possibly under a few seconds, to switch between the ENGAGED and
+# STANDBY states (in any direction).
+# Some subsystems may not differentiate between STANDBY and ENGAGED (e.g., offboard communication hardware).
+# The subsystem may disengage itself autonomously in the event of a fatal malfunction, in which case
+# the reported service health status should be WARNING.
 
 @sealed

--- a/reg/drone/srv/sensor/Status.0.1.uavcan
+++ b/reg/drone/srv/sensor/Status.0.1.uavcan
@@ -8,7 +8,7 @@ uavcan.si.unit.duration.Scalar.1.0 data_validity_period
 # Expired data should be discarded.
 
 uint32 error_count
-# Incremented once per occurrence. Reset to zero when armed.
+# Incremented once per occurrence. Reset to zero when the sensor is ENGAGED.
 # The exact definition of what constitutes an error is implementation-dependent.
 
 uavcan.si.unit.temperature.Scalar.1.0 sensor_temperature


### PR DESCRIPTION
Fixes https://github.com/UAVCAN/public_regulated_data_types/issues/90

* Introduce minor clarifications and avoid overspecification.
* Propose fix to #90 by renaming without changing the semantics:
  * Arming --> Readiness
  * DISARMED --> STANDBY
  * ARMED --> ENGAGED
