### PR TITLE
Change wording in uavcan.pnp.NodeIDAllocationData to reflect the less static nature of UAVCAN v1

### DIFF
--- a/uavcan/pnp/8165.NodeIDAllocationData.2.0.uavcan
+++ b/uavcan/pnp/8165.NodeIDAllocationData.2.0.uavcan
@@ -13,11 +13,6 @@
 # This feature relies on the concept of "anonymous message transfers", please consult with the UAVCAN transport
 # layer specification for details.
 #
-# An allocated node-ID should not be persistent. This means that if a node is configured to use plug-and-play node-ID
-# allocation, it shall perform a new allocation every time it is started or rebooted. The allocated node-ID value
-# should not be stored on the node itself, because there exist edge cases that may lead to node-ID conflicts under
-# certain circumstances (reviewed later).
-#
 # The process of plug-and-play node-ID allocation always involves two types of nodes: "allocators", which serve
 # allocation requests; and "allocatees", which request PnP node-ID from allocators. A UAVCAN network may implement
 # the following configurations of allocators:
@@ -27,7 +22,7 @@
 #
 #   - One allocator, in which case the feature of plug-and-play node-ID allocation will become unavailable
 #     if the allocator fails. In this configuration, the role of the allocator can be performed even by a very
-#     resource-constrained system, e.g. a low-end microcontroller.
+#     resource-constrained system, e.g., a low-end microcontroller.
 #
 #   - Three allocators, in which case the allocators will be using a replicated allocation table via a
 #     distributed consensus algorithm. In this configuration, the network can tolerate the loss of one

--- a/uavcan/pnp/8166.NodeIDAllocationData.1.0.uavcan
+++ b/uavcan/pnp/8166.NodeIDAllocationData.1.0.uavcan
@@ -1,6 +1,6 @@
 # This definition of the allocation message is intended for use with transports where anonymous transfers are limited
 # to 7 bytes of payload, such as Classic CAN. The definition is carried over from the original UAVCAN v0 specification
-# with some modifications. For transports other than Classic CAN (e.g., CAN FD, serial, UDP, etc.) there is a more
+# with some modifications. For transports other than Classic CAN (e.g., CAN FD, serial, etc.) there is a more
 # general, more capable definition NodeIDAllocationData v2.0. The PnP protocol itself is described in the documentation
 # for the v2 definition. The documentation provided here builds upon the general case, so read that first please.
 #


### PR DESCRIPTION
A UAVCAN v1 node is significantly less likely to be integrable into an end system without explicit prior configuration (whether manual or automated). This implies that after a PnP node is connected to the network for the first time, it will likely undergo additional configuration activities such as setting up subject-IDs and application-specific parameters (like PID gains). At this stage, most practical deployments will also commit the allocated node-ID to the non-volatile configuration to avoid reliance on the inherently non-deterministic behaviors of the PnP algorithm. This creates an unnecessary conflict with the PnP protocol specification that prohibits storing the allocated node-ID in the non-volatile configuration --- this limitation was justified for v0 but not for v1.

Existing deployments are not affected by this change.