### PR TITLE
reg.drone Battery parameters add nominal voltage

### DIFF
--- a/reg/drone/service/battery/Parameters.0.3.uavcan
+++ b/reg/drone/service/battery/Parameters.0.3.uavcan
@@ -6,7 +6,6 @@
 #
 # All parameters are required unless specifically stated otherwise.
 # For non-rechargeable batteries all "charge_*" parameters should be NaN.
-@deprecated
 
 truncated uint64 unique_id
 # A statistically unique number that can be used to identify this exact battery for logging and diagnostic purposes.
@@ -65,5 +64,8 @@ void1
 Technology.0.1 technology
 # The battery technology information may be leveraged by the charger to choose the appropriate charging strategy.
 
+uavcan.si.unit.voltage.Scalar.1.0 nominal_voltage
+# The average voltage(not per-cell) the battery outputs when charged.
+
 @assert _offset_.count == 1     # It is intended to be a fixed-size type (although it's not required).
-@extent 8 * 63                  # Limit to a single-frame transfer over CAN FD.
+@extent 8 * 67

--- a/reg/drone/service/battery/Parameters.0.3.uavcan
+++ b/reg/drone/service/battery/Parameters.0.3.uavcan
@@ -65,7 +65,9 @@ Technology.0.1 technology
 # The battery technology information may be leveraged by the charger to choose the appropriate charging strategy.
 
 uavcan.si.unit.voltage.Scalar.1.0 nominal_voltage
-# The average voltage(not per-cell) the battery outputs when charged.
+# The nominal voltage of the battery pack (not per-cell) as defined by the vendor.
+# The Smart Battery Data Specification v1.1 uses the term "design voltage".
+# E.g., a typical 22S LiCoO2 pack might report 81.4 V here.
 
 @assert _offset_.count == 1     # It is intended to be a fixed-size type (although it's not required).
 @extent 8 * 67


### PR DESCRIPTION
As discussed in #112 
Adds the nominal voltage (the voltage that's typically on battery pack) to the reg.drone.battery.parameters message.

![Battery Pack](https://images.squarespace-cdn.com/content/v1/5005ba51c4aa8b4d97619d5f/1459023107546-JT890QNTYDH9EPALIYX1/ke17ZwdGBToddI8pDm48kF_GeugBYQLVPRSRuS-Z_7V7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QPOohDIaIeljMHgDF5CVlOqpeNLcJ80NK65_fV7S1UUBb7LhCgwNO3yhps6PU5pQgxQVqvjaCMzzNIi9z0n0Tmw4iU1foAOIoZERIkCQahw/image-asset.jpeg "Battery Pack")

```
uavcan.si.unit.voltage.Scalar.1.0 nominal_voltage
# The average voltage(not per-cell) the battery outputs when charged.
```

Deprecates Parameters.0.2