### PR TITLE
reg/drone: remove redundant timestamp in Velocity3Var

### DIFF
--- a/reg/drone/physics/kinematics/cartesian/PointStateVar.0.1.uavcan
+++ b/reg/drone/physics/kinematics/cartesian/PointStateVar.0.1.uavcan
@@ -1,6 +1,6 @@
 # See PointState for details.
 
 PointVar.0.1 position
-reg.drone.physics.kinematics.translation.Velocity3Var.0.1 velocity
+reg.drone.physics.kinematics.translation.Velocity3Var.0.2 velocity
 
 @sealed

--- a/reg/drone/physics/kinematics/geodetic/PointStateVar.0.1.uavcan
+++ b/reg/drone/physics/kinematics/geodetic/PointStateVar.0.1.uavcan
@@ -1,7 +1,7 @@
 # See PointState for details.
 
 PointVar.0.1 position
-reg.drone.physics.kinematics.translation.Velocity3Var.0.1 velocity
+reg.drone.physics.kinematics.translation.Velocity3Var.0.2 velocity
 
 @sealed
 @assert _offset_ == reg.drone.physics.kinematics.cartesian.PointStateVar.0.1._bit_length_

--- a/reg/drone/physics/kinematics/translation/Velocity3Var.0.2.uavcan
+++ b/reg/drone/physics/kinematics/translation/Velocity3Var.0.2.uavcan
@@ -1,9 +1,7 @@
 # Linear velocity with covariance.
 # Observe that this is a structural subtype of uavcan.si.unit.velocity.Scalar.1.0.
 
-@deprecated
-
-uavcan.si.sample.velocity.Vector3.1.0 value
+uavcan.si.unit.velocity.Vector3.1.0 value
 float16[6] covariance_urt  # [(meter/second)^2] Upper-right triangle of the covariance matrix.
 
 @sealed


### PR DESCRIPTION
Fixes #116 